### PR TITLE
[Bugfix] Fix 30 minute courses being 1 hour on the calendar display

### DIFF
--- a/src/content/Calendar/utils.ts
+++ b/src/content/Calendar/utils.ts
@@ -53,12 +53,14 @@ export const convertToMatrix = (sections: ISectionData[], newSection: ISectionDa
                     color: section.color,
                     sectionContent: section
                 }
+                //Add the if condition since courses can be 30 minute, and only need 1 timeslot
+                if(startIndex !== endIndex) {
                 matrixDict[day][startIndex + 1] = {
                     name: number,
                     color: section.color,
                     sectionContent: section
                 }
-                
+            }
                 //populate rest of cells
                 for(let i = startIndex + 2; i <= endIndex; i++) {
                     matrixDict[day][i] = {


### PR DESCRIPTION
Fixes #77 

Originally 30 minute courses were showing as 1 hour because we always did 1 slot for the course category (i.e CPSC, PHYS), then one for the number-section (i.e 110-L1A, 213). Now if it is 30min just display the first one since no more room for the number-section. 
![image](https://github.com/mlool/workday-calendar-extension/assets/89222914/6a3e60e7-96bd-4eaf-aabb-45352725e5d9)

https://github.com/mlool/workday-calendar-extension/assets/89222914/1837cd49-3c92-4287-b7f6-8fea2ed67db4

