### PR TITLE
[Bugfix] Fix "Clustered Course Sections" Data From Displaying as Instructors

### DIFF
--- a/src/content/utils.ts
+++ b/src/content/utils.ts
@@ -175,7 +175,8 @@ export async function extractSection(element: Element) {
   
   if(instructorElements) {
     for(let i = 2; i < instructorElements.length; i++) {
-      if(!instructorElements[i].textContent?.includes("|")) {
+      //if no "|" and no "_", aka formatted like a human name, then instructor -- bandaid fix for now since registration really soon
+      if(!instructorElements[i].textContent?.includes("|") && !instructorElements[i].textContent?.includes("_")) {
         instructors.push(instructorElements[i]?.textContent || "");
       }
     }


### PR DESCRIPTION
### What Issue does this PR resolve? #94 

### Please provide a video demo below, or a screenshot and description of the change.
- Just added a check to exclude promptOption elements with a "_" in them as instructors since no "_" in an instructor name

![image](https://github.com/mlool/workday-calendar-extension/assets/89222914/19e69fff-4990-40f9-bbf7-5dd4246bccc4)


### Tag reviewers for the PR below.
@mlool 


