### PR TITLE
fix: remove faulty JSON comparison

### DIFF
--- a/src/content/App/App.tsx
+++ b/src/content/App/App.tsx
@@ -53,7 +53,7 @@ function App() {
       areaName: string
     ) => {
       if (areaName === 'sync') {
-        if (changes.newSection && JSON.stringify(changes.newSection.newValue) !== JSON.stringify(newSection)) {
+        if (changes.newSection) {
           setNewSection(changes.newSection.newValue);
         }
       }


### PR DESCRIPTION
### What Issue does this PR resolve? (Link to GitHub Issue, approved features and bugs will be given priority)

Fixes bug where 'Cancel' button doesn't do anything on Firefox (#68)

### Please provide a video demo below, or a screenshot and description of the change.

Cancel button now actually removes course section:

https://github.com/mlool/workday-calendar-extension/assets/72814106/79f43b50-5925-4fc3-b05b-01d2d9b0dfbf

(To test this out I used the [`firefox-manifest.json`](https://github.com/mlool/workday-calendar-extension/pull/99/files#diff-69336fc89b2c9f98ef87b613766ec405105290e1dfa9f264d17b1db3f3f08402) from #99)

I left a more detailed explanation on [discord](https://discord.com/channels/1245111270005542962/1245111325076754502/1249277812171608115) - essentially, the removed comparison fails on Firefox, but passes on Chrome, due to chrome's `StorageChange` not preserving insertion order.

Note: the fact that the changeset object is still the same on Chrome, but only passes the condition due to changed property order, seems like it points to a bigger issue of 'what was this comparison trying to achieve' - not sure if removing it here causes any other side effects.

### Tag reviewers for the PR below.
@mlool? not sure if there's a specific person i should be tagging here.