### PR TITLE
better handling of two term courses with 1 section

### DIFF
--- a/src/content/utils.ts
+++ b/src/content/utils.ts
@@ -77,8 +77,20 @@ const parseSectionDetails = (details: string[]): SectionDetail[] => {
     }, []);
 
     //@TODO: Change for summer term support
-    const term = dateRange.includes('2024') ? Term.winterOne : Term.winterTwo
-  
+    let term = dateRange.includes('2024') ? Term.winterOne : Term.winterTwo; 
+    if (dateRange.includes('2024') && dateRange.includes('2025')) {
+      // Case where only one section detail but two term course. Set this term to W1 and push a copy modified to be term 2
+      term = Term.winterOne
+      detailsArr.push({
+        term: Term.winterTwo,
+        days: days,
+        startTime: startTime,
+        endTime: endTime,
+        location: location,
+        dateRange: dateRange
+      })
+    }
+    
     detailsArr.push({
       term: term,
       days: days,


### PR DESCRIPTION
### What Issue does this PR resolve? (Link to GitHub Issue, approved features and bugs will be given priority) #104 

### Please provide a video demo below, or a screenshot and description of the change.
 - Bandaid fix for two term courses with 1 section until term parsing is improved to support summer terms and terms beyond 2024/25. FIxes behaviour shown in #104 

### Tag reviewers for the PR below.
