### PR TITLE
refactor: minor UI bugfixes, refactor form

### DIFF
--- a/src/content/App/App.tsx
+++ b/src/content/App/App.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useState } from 'react';
 import './App.css';
 import CalendarContainer from '../CalendarContainer/CalendarContainer';
-import { ISectionData, Term, Views, baseSection } from './App.types';
+import { ISectionData, Term, Views } from './App.types';
 import Form from '../Form/Form';
 import TopBar from '../TopBar/TopBar';
 import Settings from '../Settings/Settings';
 import { assignColors, ColorTheme } from '../../helpers/courseColors';
 
 function App() {
-  const [newSection, setNewSection] = useState<ISectionData>(baseSection);
+  const [newSection, setNewSection] = useState<ISectionData | null>(null);
   const [sections, setSections] = useState<ISectionData[]>([]);
-  const [invalidSection, setInvalidSection] = useState<boolean>(false);
+  const [sectionConflict, setSectionConflict] = useState<boolean>(false);
   const [currentWorklistNumber, setCurrentWorklistNumber] = useState<number>(0);
   const [currentTerm, setCurrentTerm] = useState<Term>(Term.winterOne);
   const [currentView, setCurrentView] = useState<Views>(Views.calendar);
@@ -75,7 +75,7 @@ function App() {
   }, [sections]);
 
   useEffect(() => {
-    if (newSection.code !== baseSection.code) {
+    if (newSection !== null) {
       if (newSection.term != Term.winterFull) {
         //Don't set the term to WF, just keep the term to what is selected
         setCurrentTerm(newSection.term);
@@ -119,7 +119,7 @@ function App() {
             sections={sections}
             setSections={setSections}
             newSection={newSection}
-            setInvalidSection={setInvalidSection}
+            setSectionConflict={setSectionConflict}
             currentWorklistNumber={currentWorklistNumber}
             setCurrentWorklistNumber={setCurrentWorklistNumber}
             currentTerm={currentTerm}
@@ -132,7 +132,7 @@ function App() {
             currentWorklistNumber={currentWorklistNumber}
             newSection={newSection}
             sections={sections}
-            invalidSection={invalidSection}
+            sectionConflict={sectionConflict}
             setNewSection={setNewSection}
             setSections={setSections}
             currentTerm={currentTerm}

--- a/src/content/App/App.types.ts
+++ b/src/content/App/App.types.ts
@@ -51,14 +51,3 @@ export interface ISectionData {
     // details: string,
     // title: string,
 }
-
-export const baseSection:ISectionData = {
-    code: "",
-    name: "",
-    instructors: [],
-    type: SectionType.lecture,
-    sectionDetails: [],
-    term: Term.winterOne,
-    worklistNumber: 0,
-    color: defaultColorList[0]
-}

--- a/src/content/Calendar/Calendar.tsx
+++ b/src/content/Calendar/Calendar.tsx
@@ -2,7 +2,6 @@ import { ISectionData, Term} from '../App/App.types'
 import { convertToMatrix, getEndHour } from './utils'
 import SectionPopup from '../SectionPopup/SectionPopup'
 import './Calendar.css'
-import { useState } from 'react';
 
 interface IProps {
   sections: ISectionData[],
@@ -17,9 +16,7 @@ interface IProps {
 
 const daysOfWeek = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 
-const Calendar = ({sections, newSection, currentWorklistNumber, setSections, setSectionConflict, currentTerm}:IProps) => {
-  const [selectedSection, setSelectedSection] = useState<ISectionData | null>(null)
-
+const Calendar = ({sections, newSection, currentWorklistNumber, setSections, setSectionConflict, currentTerm, selectedSection, setSelectedSection}:IProps) => {
   const calendarSections = sections.filter((section) => section.worklistNumber === currentWorklistNumber && (section.term === currentTerm || section.term == Term.winterFull))
   const sectionsToRender = convertToMatrix(calendarSections, newSection, setSectionConflict, currentTerm)
 

--- a/src/content/Calendar/Calendar.tsx
+++ b/src/content/Calendar/Calendar.tsx
@@ -6,22 +6,22 @@ import { useState } from 'react';
 
 interface IProps {
   sections: ISectionData[],
-  newSection: ISectionData,
+  newSection: ISectionData | null,
   currentWorklistNumber: number,
   currentTerm: Term,
   selectedSection: ISectionData | null;
   setSections: (data: ISectionData[]) => void,
-  setInvalidSection: (state: boolean) => void,
+  setSectionConflict: (state: boolean) => void,
   setSelectedSection: (section: ISectionData | null) => void;
 }
 
 const daysOfWeek = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 
-const Calendar = ({sections, newSection, currentWorklistNumber, setSections, setInvalidSection, currentTerm}:IProps) => {
+const Calendar = ({sections, newSection, currentWorklistNumber, setSections, setSectionConflict, currentTerm}:IProps) => {
   const [selectedSection, setSelectedSection] = useState<ISectionData | null>(null)
 
   const calendarSections = sections.filter((section) => section.worklistNumber === currentWorklistNumber && (section.term === currentTerm || section.term == Term.winterFull))
-  const sectionsToRender = convertToMatrix(calendarSections, newSection, setInvalidSection, currentTerm)
+  const sectionsToRender = convertToMatrix(calendarSections, newSection, setSectionConflict, currentTerm)
 
   let times: string[] = [];
   for (let hour = 7; hour <= getEndHour(sectionsToRender); hour++) {

--- a/src/content/Calendar/utils.ts
+++ b/src/content/Calendar/utils.ts
@@ -6,7 +6,7 @@ export interface CellFormat {
     sectionContent: ISectionData | null,
 }
 
-export const convertToMatrix = (sections: ISectionData[], newSection: ISectionData, setInvalidSection: (state: boolean) => void, currentTerm: Term) => {
+export const convertToMatrix = (sections: ISectionData[], newSection: ISectionData | null, setSectionConflict: (state: boolean) => void, currentTerm: Term) => {
     let matrixDict: {[id: string]: CellFormat[]} = {
         "Mon": [],
         "Tue": [],
@@ -100,8 +100,8 @@ export const convertToMatrix = (sections: ISectionData[], newSection: ISectionDa
     })
 
     //Deal with newSection
-    let hasInvalidSection = !(newSection.sectionDetails.length > 0)
-    newSection.sectionDetails.forEach((details) => {
+    let hasInvalidSection = newSection !== null && !(newSection?.sectionDetails.length > 0)
+    newSection?.sectionDetails.forEach((details) => {
         if(details.term !== currentTerm) {
             return;
         }
@@ -129,7 +129,7 @@ export const convertToMatrix = (sections: ISectionData[], newSection: ISectionDa
         })
     })
 
-    setInvalidSection(hasInvalidSection)
+    setSectionConflict(hasInvalidSection)
     return matrixDict
 };
 

--- a/src/content/CalendarContainer/CalendarContainer.tsx
+++ b/src/content/CalendarContainer/CalendarContainer.tsx
@@ -1,30 +1,30 @@
-import { ISectionData, Term_String_Map, Term, baseSection } from '../App/App.types'
+import { ISectionData, Term_String_Map, Term } from '../App/App.types'
 import Calendar from '../Calendar/Calendar';
 import './CalendarContainer.css'
 
 interface IProps {
   sections: ISectionData[],
-  newSection: ISectionData,
+  newSection: ISectionData | null,
   currentWorklistNumber: number,
   currentTerm: Term,
   selectedSection: ISectionData | null,
   setCurrentWorklistNumber: (num: number) => void,
   setSections: (data: ISectionData[]) => void,
-  setInvalidSection: (state: boolean) => void,
+  setSectionConflict: (state: boolean) => void,
   setCurrentTerm: (term: Term) => void;
   setSelectedSection: (section: ISectionData | null) => void;
 }
 
-const CalendarContainer = ({sections, newSection, currentWorklistNumber, setSections, setInvalidSection, setCurrentWorklistNumber, currentTerm, setCurrentTerm, selectedSection, setSelectedSection}:IProps) => {
+const CalendarContainer = ({sections, newSection, currentWorklistNumber, setSections, setSectionConflict, setCurrentWorklistNumber, currentTerm, setCurrentTerm, selectedSection, setSelectedSection}:IProps) => {
   const WORKLISTCOUNT = [0, 1, 2, 3]
   const TERMS = [Term.winterOne, Term.winterTwo]
 
   const getBackgroundColour = (term: Term): string => {
     if(currentTerm === term){
       return "#9ce8ff";
-    } else if (newSection.term === Term.winterFull) {
+    } else if (newSection?.term === Term.winterFull) {
       return "#ffa500"; //If not selected term, but newSection term is winterFull, orange to indicate course in other term also
-    } else if (newSection.code !== baseSection.code){
+    } else if (newSection !== null){
       return "#f7faff" //Gray out if section selected & not correct term
     } else {
       return ""
@@ -33,11 +33,11 @@ const CalendarContainer = ({sections, newSection, currentWorklistNumber, setSect
 
   const canSwitchTerms = (term: Term): boolean => {
     let rsf = true;
-    if (newSection.code !== baseSection.code) {
+    if (newSection !== null) {
       rsf = false //False if we have a section selected
     }
 
-    if(newSection.term === Term.winterFull) {
+    if(newSection?.term === Term.winterFull) {
       rsf = true //But if our term is winterFull, then we should allow switching term no matter what
     }
     return rsf;
@@ -46,9 +46,9 @@ const CalendarContainer = ({sections, newSection, currentWorklistNumber, setSect
   const getFontColor = (term: Term): string => {
     if(currentTerm === term){
       return "black";
-    } else if (newSection.term === Term.winterFull) {
+    } else if (newSection?.term === Term.winterFull) {
       return "black"; //black still
-    } else if (newSection.code !== baseSection.code){
+    } else if (newSection !== null){
       return "#d4d4d4" //Gray out if section selected & not correct term
     } else {
       return ""
@@ -84,7 +84,7 @@ const CalendarContainer = ({sections, newSection, currentWorklistNumber, setSect
         currentWorklistNumber={currentWorklistNumber}
         newSection={newSection} 
         setSections={setSections} 
-        setInvalidSection={setInvalidSection} 
+        setSectionConflict={setSectionConflict} 
         currentTerm={currentTerm}
         selectedSection={selectedSection}
         setSelectedSection={setSelectedSection}

--- a/src/content/Form/Form.css
+++ b/src/content/Form/Form.css
@@ -48,5 +48,9 @@
 }
 
 .NewSectionButton:hover {
-    background-color: #0068d6;;
+    background-color: #0068d6;
+}
+
+.NewSectionButton:disabled {
+    background-color: #c4c4c4;
 }

--- a/src/content/Form/Form.tsx
+++ b/src/content/Form/Form.tsx
@@ -1,77 +1,66 @@
-import { ColorTheme, getNewSectionColor } from '../../helpers/courseColors'
-import { ISectionData, Term } from '../App/App.types'
-import './Form.css'
-import ConfirmationModal from '../ConfirmationModal/ConfirmationModal'
-import { useState } from 'react';
+import { ISectionData } from "../App/App.types";
+import "./Form.css";
+import ConfirmationModal from "../ConfirmationModal/ConfirmationModal";
+import { useState } from "react";
 
 interface IProps {
-    newSection: ISectionData | null,
-    sections: ISectionData[],
-    sectionConflict: boolean,
-    currentWorklistNumber: number,
-    setNewSection: (data: ISectionData | null) => void,
-    setSections: (data: ISectionData[]) => void,
-    currentTerm: Term;
-    colorTheme: ColorTheme,
-    setColorTheme: (theme: ColorTheme) => void,
-    setSelectedSection: (section: ISectionData | null) => void;
+  newSection: ISectionData | null;
+  sectionConflict: boolean;
+  currentWorklistNumber: number;
+  handleAddNewSection: () => void;
+  handleClearWorklist: () => void;
+  handleCancel: () => void;
 }
 
-const Form = ({newSection, sections, sectionConflict, currentWorklistNumber, setNewSection, setSections, colorTheme, setSelectedSection}: IProps) => {
-  const [showConfirmation, setShowConfirmation] = useState<boolean>(false)
-  
-  const onAdd = () => {
-    if (sectionConflict) return;
-    let updatedNewSection = newSection!;
-    updatedNewSection.worklistNumber = currentWorklistNumber
-    updatedNewSection.color = getNewSectionColor(sections, updatedNewSection, colorTheme)
-
-    let newSections = [...sections]
-    
-    newSections.push(updatedNewSection)
-    setSections(newSections)
-    setNewSection(null);
-  }
-
-  const onCancel = () => {
-    setNewSection(null);
-  };
-
-  const onClear = () => {
-    let newSections:ISectionData[] = []
-    sections.forEach((section) => {
-      if (section.worklistNumber !== currentWorklistNumber) {
-        newSections.push({...section})
-      }
-    })
-    setSections(newSections)
-  }
+const Form = (props: IProps) => {
+  const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
 
   return (
-    <div className='NewSectionForm'>
-      {showConfirmation && 
-        <ConfirmationModal 
-          title='Confirm Clear Worklist' 
-          message={`Clearing the worklist will remove all sections from both terms under worklist ${currentWorklistNumber}. Are you sure you want to continue?` }
-          onCancel={() => setShowConfirmation(false)} 
+    <div className="NewSectionForm">
+      {showConfirmation && (
+        <ConfirmationModal
+          title="Confirm Clear Worklist"
+          message={`Clearing the worklist will remove all sections from both terms under worklist ${props.currentWorklistNumber}. Are you sure you want to continue?`}
+          onCancel={() => setShowConfirmation(false)}
           onConfirm={() => {
-                      onClear()
-                      setShowConfirmation(false)
-                      setSelectedSection(null)
-                    }}
+            props.handleClearWorklist();
+            setShowConfirmation(false);
+          }}
         />
-      }
-      <div className="NewSectionInfo">
-        <div className="NewSectionCode">{newSection?.code}</div>
-        <div>{newSection?.name}</div>
+      )}
+      {props.newSection && (
+        <div className="NewSectionInfo">
+          <div className="NewSectionCode">{props.newSection.code}</div>
+          <div>{props.newSection.name}</div>
+        </div>
+      )}
+      <div className="NewSectionButtonContainer">
+        <button
+          className="NewSectionButton"
+          disabled={props.newSection === null}
+          title="Cancel"
+          onClick={props.handleCancel}
+        >
+          Cancel
+        </button>
+        <button
+          className="NewSectionButton"
+          disabled={props.sectionConflict || props.newSection === null}
+          title="Add Section"
+          onClick={props.handleAddNewSection}
+        >
+          Add Section
+        </button>
       </div>
-      <div className='NewSectionButtonContainer'>
-        <div className="NewSectionButton" title="Cancel"onClick={onCancel} style={{backgroundColor: (sectionConflict && (!newSection?.code && !newSection?.name)) ? "#c4c4c4" : "" }}>Cancel</div>
-        <div className="NewSectionButton" title="Add Section" onClick={onAdd} style={{backgroundColor: sectionConflict? "#c4c4c4": ""}}>Add Section</div>
+      <div
+        className="ClearWorklistButton"
+        title="Clear Worklist"
+        onClick={() => setShowConfirmation(true)}
+      >
+        Clear Worklist
       </div>
-      <div className="ClearWorklistButton" title="Clear Worklist" onClick={() => setShowConfirmation(true)}>Clear Worklist</div>
     </div>
-  )
-}
+  );
+};
 
-export default Form
+export default Form;

--- a/src/content/Form/Form.tsx
+++ b/src/content/Form/Form.tsx
@@ -1,15 +1,15 @@
 import { ColorTheme, getNewSectionColor } from '../../helpers/courseColors'
-import { ISectionData, Term, baseSection } from '../App/App.types'
+import { ISectionData, Term } from '../App/App.types'
 import './Form.css'
 import ConfirmationModal from '../ConfirmationModal/ConfirmationModal'
 import { useState } from 'react';
 
 interface IProps {
-    newSection: ISectionData,
+    newSection: ISectionData | null,
     sections: ISectionData[],
-    invalidSection: boolean,
+    sectionConflict: boolean,
     currentWorklistNumber: number,
-    setNewSection: (data: ISectionData) => void,
+    setNewSection: (data: ISectionData | null) => void,
     setSections: (data: ISectionData[]) => void,
     currentTerm: Term;
     colorTheme: ColorTheme,
@@ -17,12 +17,12 @@ interface IProps {
     setSelectedSection: (section: ISectionData | null) => void;
 }
 
-const Form = ({newSection, sections, invalidSection, currentWorklistNumber, setNewSection, setSections, currentTerm, colorTheme, setColorTheme, setSelectedSection}: IProps) => {
+const Form = ({newSection, sections, sectionConflict, currentWorklistNumber, setNewSection, setSections, colorTheme, setSelectedSection}: IProps) => {
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false)
   
   const onAdd = () => {
-    if (invalidSection) return;
-    let updatedNewSection = newSection;
+    if (sectionConflict) return;
+    let updatedNewSection = newSection!;
     updatedNewSection.worklistNumber = currentWorklistNumber
     updatedNewSection.color = getNewSectionColor(sections, updatedNewSection, colorTheme)
 
@@ -30,12 +30,11 @@ const Form = ({newSection, sections, invalidSection, currentWorklistNumber, setN
     
     newSections.push(updatedNewSection)
     setSections(newSections)
-    chrome.storage.sync.set({ newSection: baseSection });
+    setNewSection(null);
   }
 
   const onCancel = () => {
-    // setNewSection(baseSection)
-    chrome.storage.sync.set({ newSection: baseSection });
+    setNewSection(null);
   };
 
   const onClear = () => {
@@ -63,12 +62,12 @@ const Form = ({newSection, sections, invalidSection, currentWorklistNumber, setN
         />
       }
       <div className="NewSectionInfo">
-        <div className="NewSectionCode">{newSection.code}</div>
-        <div>{newSection.name}</div>
+        <div className="NewSectionCode">{newSection?.code}</div>
+        <div>{newSection?.name}</div>
       </div>
       <div className='NewSectionButtonContainer'>
-        <div className="NewSectionButton" title="Cancel"onClick={onCancel} style={{backgroundColor: (invalidSection && (!newSection.code && !newSection.name)) ? "#c4c4c4" : "" }}>Cancel</div>
-        <div className="NewSectionButton" title="Add Section" onClick={onAdd} style={{backgroundColor: invalidSection? "#c4c4c4": ""}}>Add Section</div>
+        <div className="NewSectionButton" title="Cancel"onClick={onCancel} style={{backgroundColor: (sectionConflict && (!newSection?.code && !newSection?.name)) ? "#c4c4c4" : "" }}>Cancel</div>
+        <div className="NewSectionButton" title="Add Section" onClick={onAdd} style={{backgroundColor: sectionConflict? "#c4c4c4": ""}}>Add Section</div>
       </div>
       <div className="ClearWorklistButton" title="Clear Worklist" onClick={() => setShowConfirmation(true)}>Clear Worklist</div>
     </div>


### PR DESCRIPTION
### What Issue does this PR resolve? (Link to GitHub Issue, approved features and bugs will be given priority)

PR implements the following...

minor UI bugfixes:
- fixes bug where `SectionPopup` does not close when worklist is cleared
- fixes bug where "Add Section" button is still clickable when no `newSection` exists
- greys out "Cancel" and "Add Section" buttons when no `newSection` exists, using button's `disabled` attribute
- prevent additional `App` rerender from `useEffect` updating `currentTerm`

code cleanups:
- remove `baseSection`, making `newSection` nullable instead for clarity
- rename `invalidSection` to `sectionConflict` for clarity on what 'invalid' means
- move form action handlers to `App` to avoid needing to pass so many props down to `Form`
- run prettier on `Form.tsx` (didn't run on the other files to avoid creating a huge diff)

### Please provide a video demo below, or a screenshot and description of the change.
https://github.com/mlool/workday-calendar-extension/assets/72814106/e74c29d0-99f2-4dbd-a333-73ef6375f1f6

### Tag reviewers for the PR below.
@mlool 