### PR TITLE
fix: update storage when section add is canceled

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "cross-env INLINE_RUNTIME_CHUNK=false react-app-rewired build",
+    "build-firefox": "yarn run build && cp firefox-manifest.json build/manifest.json",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/content/App/App.tsx
+++ b/src/content/App/App.tsx
@@ -50,6 +50,7 @@ function App() {
     ) => {
       if (changes.newSection) {
         const newVal = changes.newSection.newValue
+        if (newVal === null) return;
         setNewSection(newVal);
         if (newVal.term !== Term.winterFull) {
           //Don't set the term to WF, just keep the term to what is selected
@@ -114,6 +115,11 @@ function App() {
     setNewSection(null);
   }
 
+  const handleCancelNewSection = () => {
+    setNewSection(null);
+    chrome.storage.local.set({ "newSection": null })
+  }
+
   const handleClearWorklist = () => {
     const updatedSections = sections.filter(
       (x) => x.worklistNumber !== currentWorklistNumber
@@ -146,7 +152,7 @@ function App() {
             sectionConflict={sectionConflict}
             handleAddNewSection={handleAddNewSection}
             handleClearWorklist={handleClearWorklist}
-            handleCancel={() => setNewSection(null)}
+            handleCancel={handleCancelNewSection}
           />
         </div>
       ) : (


### PR DESCRIPTION
### What Issue does this PR resolve? (Link to GitHub Issue, approved features and bugs will be given priority)

- Fixes bug where after a section add was canceled, the section could not be readded.

### Tag reviewers for the PR below.
@mlool 