### PR TITLE
fixed async loading on import courses

### DIFF
--- a/src/content/Settings/ExportImport/ExportImport.tsx
+++ b/src/content/Settings/ExportImport/ExportImport.tsx
@@ -44,21 +44,22 @@ const ExportImport = ({ sections, setSections }: IProps) => {
   }
 
   const handleSectionImport = async (sections: ISectionData[]) => {
-    const fetchedCourseIDs: Promise<string>[] = []
-    for (const section of sections) {
+    const fetchedCourseIDs: string[] = []
+    await sections.reduce(async (promise, section) => {
+      await promise;
       if (!section.courseID) {
-        fetchedCourseIDs.push(findCourseId(section.code))
+        const courseID = await findCourseId(section.code)
+        fetchedCourseIDs.push(courseID);
       }
-    }
+    }, Promise.resolve())
 
-    const courseIDs = await Promise.all(fetchedCourseIDs)
     const newSections = sections.map((s) => {
-      if (s.courseID) return s
+      if (s.courseID) return s;
       return {
-        ...s,
-        courseID: courseIDs.shift(),
-      }
-    })
+          ...s,
+          courseID: fetchedCourseIDs.shift(),
+      };
+    });
 
     setSections(newSections)
     setImportInProgress(false)

--- a/src/content/Settings/ExportImport/ExportImport.tsx
+++ b/src/content/Settings/ExportImport/ExportImport.tsx
@@ -46,20 +46,20 @@ const ExportImport = ({ sections, setSections }: IProps) => {
   const handleSectionImport = async (sections: ISectionData[]) => {
     const fetchedCourseIDs: string[] = []
     await sections.reduce(async (promise, section) => {
-      await promise;
+      await promise
       if (!section.courseID) {
         const courseID = await findCourseId(section.code)
-        fetchedCourseIDs.push(courseID);
+        fetchedCourseIDs.push(courseID)
       }
     }, Promise.resolve())
 
     const newSections = sections.map((s) => {
-      if (s.courseID) return s;
+      if (s.courseID) return s
       return {
-          ...s,
-          courseID: fetchedCourseIDs.shift(),
-      };
-    });
+        ...s,
+        courseID: fetchedCourseIDs.shift(),
+      }
+    })
 
     setSections(newSections)
     setImportInProgress(false)


### PR DESCRIPTION
### What Issue does this PR resolve? (Link to GitHub Issue, approved features and bugs will be given priority)
Fixes issue when importing courses are handled async causes too many concurrent request bug

### Please provide a video demo below, or a screenshot and description of the change.

### Tag reviewers for the PR below.
