### PR TITLE
refactor: remove selectedSection, add TabBar component

### DIFF
--- a/src/components/TabBar.css
+++ b/src/components/TabBar.css
@@ -1,13 +1,14 @@
 .tab-bar-container {
   display: grid;
-  grid-auto-flow: column;
+  grid-template-columns: 20% 1fr;
   column-gap: 5px;
   align-items: center;
-  padding: 3px 5px;
+  padding: 2px 5px;
 }
 
 .tab-bar-label {
   font-weight: 500;
+  text-align: left;
 }
 
 .tab-bar {

--- a/src/components/TabBar.css
+++ b/src/components/TabBar.css
@@ -1,0 +1,40 @@
+.tab-bar-container {
+  display: grid;
+  grid-auto-flow: column;
+  column-gap: 5px;
+  align-items: center;
+  padding: 3px 5px;
+}
+
+.tab-bar-label {
+  font-weight: 500;
+}
+
+.tab-bar {
+  display: grid;
+  grid-auto-flow: column;
+  column-gap: 3px;
+}
+
+.tab-bar-button {
+  cursor: pointer;
+  font-size: 12px;
+  padding: 3px 5px;
+  border-radius: 3px;
+}
+
+.tab-selected {
+  background-color: var(--secondary-accent-colour)
+}
+
+.tab-highlighted {
+  background-color: var(--highlight-colour)
+}
+
+.tab-backgrounded {
+  background-color: var(--disabled-colour)
+}
+
+.tab-backgrounded:hover {
+  background-color: var(--secondary-accent-colour)
+}

--- a/src/components/TabBar.css
+++ b/src/components/TabBar.css
@@ -25,17 +25,17 @@
 }
 
 .tab-selected {
-  background-color: var(--secondary-accent-colour)
+  background-color: var(--secondary-accent-colour);
 }
 
 .tab-highlighted {
-  background-color: var(--highlight-colour)
+  background-color: var(--highlight-colour);
 }
 
 .tab-backgrounded {
-  background-color: var(--disabled-colour)
+  background-color: var(--disabled-colour);
 }
 
 .tab-backgrounded:hover {
-  background-color: var(--secondary-accent-colour)
+  background-color: var(--secondary-accent-colour);
 }

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,24 +1,25 @@
 import "./TabBar.css"
 
-interface TabBarProps<Type> {
-  label: string
-  items: Type[]
-  onClickHandler: (item: Type) => void
-  isSelected: (item: Type) => boolean
-  isHighlighted?: (item: Type) => boolean
+interface TabBarProps<T> {
+  label?: string
+  items: T[]
+  onClickHandler: (item: T) => void
+  isSelected: (item: T) => boolean
+  isHighlighted?: (item: T) => boolean
+  tabTextBuilder?: (item: T) => string
 }
 
-export default function TabBar<Type>(props: TabBarProps<Type>) {
-  const determineTabColor = (item: Type) => {
+export default function TabBar<T>(props: TabBarProps<T>) {
+  const determineTabColor = (item: T) => {
     if (props.isSelected(item)) return "tab-selected"
     if (props.isHighlighted && props.isHighlighted(item))
-      return "tab-higlighted"
+      return "tab-highlighted"
     return "tab-backgrounded"
   }
 
   return (
     <div className="tab-bar-container">
-      <p className="tab-bar-label">{props.label}</p>
+      {props.label && <p className="tab-bar-label">{props.label}</p>}
       <div className="tab-bar">
         {props.items.map((item, index) => (
           <div
@@ -26,7 +27,7 @@ export default function TabBar<Type>(props: TabBarProps<Type>) {
             className={`tab-bar-button ${determineTabColor(item)}`}
             onClick={() => props.onClickHandler(item)}
           >
-            {String(item)}
+            {props.tabTextBuilder ? props.tabTextBuilder(item) : String(item)}
           </div>
         ))}
       </div>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,0 +1,35 @@
+import "./TabBar.css"
+
+interface TabBarProps<Type> {
+  label: string
+  items: Type[]
+  onClickHandler: (item: Type) => void
+  isSelected: (item: Type) => boolean
+  isHighlighted?: (item: Type) => boolean
+}
+
+export default function TabBar<Type>(props: TabBarProps<Type>) {
+  const determineTabColor = (item: Type) => {
+    if (props.isSelected(item)) return "tab-selected"
+    if (props.isHighlighted && props.isHighlighted(item))
+      return "tab-higlighted"
+    return "tab-backgrounded"
+  }
+
+  return (
+    <div className="tab-bar-container">
+      <p className="tab-bar-label">{props.label}</p>
+      <div className="tab-bar">
+        {props.items.map((item, index) => (
+          <div
+            key={index}
+            className={`tab-bar-button ${determineTabColor(item)}`}
+            onClick={() => props.onClickHandler(item)}
+          >
+            {String(item)}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/content/App/App.test.tsx
+++ b/src/content/App/App.test.tsx
@@ -1,9 +1,0 @@
-import React from "react"
-import { render, screen } from "@testing-library/react"
-import App from "./App"
-
-test("renders learn react link", () => {
-  render(<App />)
-  const linkElement = screen.getByText(/learn react/i)
-  expect(linkElement).toBeInTheDocument()
-})

--- a/src/content/App/App.tsx
+++ b/src/content/App/App.tsx
@@ -165,7 +165,8 @@ function App() {
   }
 
   const handleDeleteSection = (sectionToDelete: ISectionData) => {
-    setSections(sections.filter((s) => s !== sectionToDelete))}
+    setSections(sections.filter((s) => s !== sectionToDelete))
+  }
 
   const handleCancelNewSection = () => {
     setNewSection(null)

--- a/src/content/App/App.tsx
+++ b/src/content/App/App.tsx
@@ -26,9 +26,7 @@ function App() {
   const [currentTerm, setCurrentTerm] = useState<Term>(Term.winterOne)
   const [currentView, setCurrentView] = useState<Views>(Views.calendar)
   const [colorTheme, setColorTheme] = useState<ColorTheme>(ColorTheme.Green)
-  const [selectedSection, setSelectedSection] = useState<ISectionData | null>(
-    null
-  )
+
   const dispatchModal = useContext(ModalDispatchContext)
 
   const handleSectionImport = async (sections: ISectionData[]) => {
@@ -166,10 +164,8 @@ function App() {
     chrome.storage.local.set({ newSection: null })
   }
 
-  const handleDeleteSelectedSection = () => {
-    setSections(sections.filter((s) => s !== selectedSection))
-    setSelectedSection(null)
-  }
+  const handleDeleteSection = (sectionToDelete: ISectionData) => {
+    setSections(sections.filter((s) => s !== sectionToDelete))}
 
   const handleCancelNewSection = () => {
     setNewSection(null)
@@ -181,15 +177,13 @@ function App() {
       (x) => x.worklistNumber !== currentWorklistNumber
     )
     setSections(updatedSections)
-    setSelectedSection(null)
   }
 
   return (
     <ModalLayer
       currentWorklistNumber={currentWorklistNumber}
       handleClearWorklist={handleClearWorklist}
-      handleDeleteSelectedSection={handleDeleteSelectedSection}
-      setSelectedSection={setSelectedSection}
+      handleDeleteSection={handleDeleteSection}
     >
       <div className="App">
         <TopBar currentView={currentView} setCurrentView={setCurrentView} />
@@ -204,8 +198,6 @@ function App() {
               setCurrentWorklistNumber={setCurrentWorklistNumber}
               currentTerm={currentTerm}
               setCurrentTerm={setCurrentTerm}
-              selectedSection={selectedSection}
-              setSelectedSection={setSelectedSection}
             />
 
             <Form

--- a/src/content/Calendar/Calendar.tsx
+++ b/src/content/Calendar/Calendar.tsx
@@ -9,10 +9,8 @@ interface IProps {
   newSection: ISectionData | null
   currentWorklistNumber: number
   currentTerm: Term
-  selectedSection: ISectionData | null
   setSections: (data: ISectionData[]) => void
   setSectionConflict: (state: boolean) => void
-  setSelectedSection: (section: ISectionData | null) => void
 }
 
 const daysOfWeek = ["Mon", "Tue", "Wed", "Thu", "Fri"]
@@ -23,7 +21,6 @@ const Calendar = ({
   currentWorklistNumber,
   setSectionConflict,
   currentTerm,
-  setSelectedSection,
 }: IProps) => {
   const dispatchModal = useContext(ModalDispatchContext)
 
@@ -77,7 +74,6 @@ const Calendar = ({
                 style={{ backgroundColor: cell.color }}
                 onClick={() => {
                   if (cell.sectionContent === null) return
-                  setSelectedSection(cell.sectionContent)
                   dispatchModal({
                     preset: ModalPreset.SectionPopup,
                     additionalData: cell.sectionContent,

--- a/src/content/CalendarContainer/CalendarContainer.css
+++ b/src/content/CalendarContainer/CalendarContainer.css
@@ -1,28 +1,9 @@
 .CalendarContainer {
-  /* height: 100%; */
-  /* overflow: hidden; */
   flex-grow: 1;
 }
 
-.HeaderSectionContainer {
-  display: flex;
-  justify-content: space-between;
-  padding: 3px;
-}
-
 .HeaderItemContainer {
-  display: flex;
-}
-
-.HeaderButton {
-  margin-right: 3px;
-  cursor: pointer;
-  background-color: #f2fcff;
-  font-size: 12px;
-  border-radius: 3px;
-  padding: 3px 5px;
-}
-
-.HeaderButton:hover {
-  background-color: #9ce8ff;
+  display: grid;
+  margin-top: 2px;
+  margin-bottom: 5px;
 }

--- a/src/content/CalendarContainer/CalendarContainer.tsx
+++ b/src/content/CalendarContainer/CalendarContainer.tsx
@@ -1,3 +1,4 @@
+import TabBar from "../../components/TabBar"
 import { ISectionData, Term_String_Map, Term } from "../App/App.types"
 import Calendar from "../Calendar/Calendar"
 import "./CalendarContainer.css"
@@ -65,20 +66,13 @@ const CalendarContainer = ({
   return (
     <div className="CalendarContainer">
       <div className="HeaderItemContainer">
-        <div style={{ padding: "3px 5px" }}>Worklists: </div>
-        {WORKLISTCOUNT.map((num) => (
-          <div
-            key={num}
-            className="HeaderButton"
-            id={`work${num}`}
-            onClick={() => setCurrentWorklistNumber(num)}
-            style={{
-              backgroundColor: num === currentWorklistNumber ? "#9ce8ff" : "",
-            }}
-          >
-            {num}
-          </div>
-        ))}
+        <TabBar
+          label="Worklists"
+          items={WORKLISTCOUNT}
+          onClickHandler={setCurrentWorklistNumber}
+          isSelected={(x) => x === currentWorklistNumber}
+          isHighlighted={() => newSection?.term === Term.winterFull}
+        />
         <div style={{ padding: "3px 5px" }}>Terms: </div>
         {TERMS.map((term) => (
           <div

--- a/src/content/CalendarContainer/CalendarContainer.tsx
+++ b/src/content/CalendarContainer/CalendarContainer.tsx
@@ -27,40 +27,9 @@ const CalendarContainer = ({
   const WORKLISTCOUNT = [0, 1, 2, 3]
   const TERMS = [Term.winterOne, Term.winterTwo]
 
-  const getBackgroundColour = (term: Term): string => {
-    if (currentTerm === term) {
-      return "#9ce8ff"
-    } else if (newSection?.term === Term.winterFull) {
-      return "#ffa500" //If not selected term, but newSection term is winterFull, orange to indicate course in other term also
-    } else if (newSection !== null) {
-      return "#f7faff" //Gray out if section selected & not correct term
-    } else {
-      return ""
-    }
-  }
-
   const canSwitchTerms = (): boolean => {
-    let rsf = true
-    if (newSection !== null) {
-      rsf = false //False if we have a section selected
-    }
-
-    if (newSection?.term === Term.winterFull) {
-      rsf = true //But if our term is winterFull, then we should allow switching term no matter what
-    }
-    return rsf
-  }
-
-  const getFontColor = (term: Term): string => {
-    if (currentTerm === term) {
-      return "black"
-    } else if (newSection?.term === Term.winterFull) {
-      return "black" //black still
-    } else if (newSection !== null) {
-      return "#d4d4d4" //Gray out if section selected & not correct term
-    } else {
-      return ""
-    }
+    if (newSection !== null && newSection.term !== Term.winterFull) return false
+    return true
   }
 
   return (
@@ -75,7 +44,9 @@ const CalendarContainer = ({
         <TabBar
           label="Terms"
           items={TERMS}
-          onClickHandler={(term) => (canSwitchTerms() ? setCurrentTerm(term) : null)}
+          onClickHandler={(term) =>
+            canSwitchTerms() ? setCurrentTerm(term) : null
+          }
           isSelected={(x) => x === currentTerm}
           isHighlighted={() => newSection?.term === Term.winterFull}
           tabTextBuilder={(x) => Term_String_Map[x]}

--- a/src/content/CalendarContainer/CalendarContainer.tsx
+++ b/src/content/CalendarContainer/CalendarContainer.tsx
@@ -71,23 +71,15 @@ const CalendarContainer = ({
           items={WORKLISTCOUNT}
           onClickHandler={setCurrentWorklistNumber}
           isSelected={(x) => x === currentWorklistNumber}
-          isHighlighted={() => newSection?.term === Term.winterFull}
         />
-        <div style={{ padding: "3px 5px" }}>Terms: </div>
-        {TERMS.map((term) => (
-          <div
-            key={term}
-            className="HeaderButton"
-            id={`term_${Term_String_Map[term]}`}
-            onClick={() => (canSwitchTerms() ? setCurrentTerm(term) : null)}
-            style={{
-              backgroundColor: getBackgroundColour(term),
-              color: getFontColor(term),
-            }}
-          >
-            {Term_String_Map[term]}
-          </div>
-        ))}
+        <TabBar
+          label="Terms"
+          items={TERMS}
+          onClickHandler={(term) => (canSwitchTerms() ? setCurrentTerm(term) : null)}
+          isSelected={(x) => x === currentTerm}
+          isHighlighted={() => newSection?.term === Term.winterFull}
+          tabTextBuilder={(x) => Term_String_Map[x]}
+        />
       </div>
 
       <Calendar

--- a/src/content/CalendarContainer/CalendarContainer.tsx
+++ b/src/content/CalendarContainer/CalendarContainer.tsx
@@ -7,12 +7,10 @@ interface IProps {
   newSection: ISectionData | null
   currentWorklistNumber: number
   currentTerm: Term
-  selectedSection: ISectionData | null
   setCurrentWorklistNumber: (num: number) => void
   setSections: (data: ISectionData[]) => void
   setSectionConflict: (state: boolean) => void
   setCurrentTerm: (term: Term) => void
-  setSelectedSection: (section: ISectionData | null) => void
 }
 
 const CalendarContainer = ({
@@ -24,8 +22,6 @@ const CalendarContainer = ({
   setCurrentWorklistNumber,
   currentTerm,
   setCurrentTerm,
-  selectedSection,
-  setSelectedSection,
 }: IProps) => {
   const WORKLISTCOUNT = [0, 1, 2, 3]
   const TERMS = [Term.winterOne, Term.winterTwo]
@@ -107,8 +103,6 @@ const CalendarContainer = ({
         setSections={setSections}
         setSectionConflict={setSectionConflict}
         currentTerm={currentTerm}
-        selectedSection={selectedSection}
-        setSelectedSection={setSelectedSection}
       />
     </div>
   )

--- a/src/content/ModalLayer.tsx
+++ b/src/content/ModalLayer.tsx
@@ -2,7 +2,6 @@ import {
   createContext,
   Dispatch,
   Reducer,
-  SetStateAction,
   useContext,
   useReducer,
 } from "react"
@@ -59,8 +58,7 @@ interface SyncScheduleModalData {
 interface ModalLayerProps {
   currentWorklistNumber: number
   handleClearWorklist: VoidCallback
-  handleDeleteSelectedSection: VoidCallback
-  setSelectedSection: Dispatch<SetStateAction<ISectionData | null>>
+  handleDeleteSection: (sectionToDelete: ISectionData) => void
   children: JSX.Element
 }
 
@@ -99,8 +97,7 @@ function ModalLayer(props: ModalLayerProps) {
           body: <SectionInfoBody selectedSection={sectionData} />,
           closeButtonText: "Close",
           actionButtonText: "Remove",
-          actionHandler: props.handleDeleteSelectedSection,
-          cancelHandler: () => props.setSelectedSection(null),
+          actionHandler: () => props.handleDeleteSection(sectionData),
           alignment: ModalAlignment.Top,
           hasTintedBg: false,
         }

--- a/src/content/ModalLayer.tsx
+++ b/src/content/ModalLayer.tsx
@@ -1,10 +1,4 @@
-import {
-  createContext,
-  Dispatch,
-  Reducer,
-  useContext,
-  useReducer,
-} from "react"
+import { createContext, Dispatch, Reducer, useContext, useReducer } from "react"
 import { ISectionData } from "./App/App.types"
 import "./ModalLayer.css"
 import SectionInfoBody from "./SectionPopup/SectionInfoBody"

--- a/src/content/SectionPopup/GradesComponent/GradesComponent.tsx
+++ b/src/content/SectionPopup/GradesComponent/GradesComponent.tsx
@@ -1,14 +1,13 @@
 import { useEffect, useState } from "react"
 import { IGradesAPIData, getGradesData, getGradesUrl } from "./GradesHelper"
-import { ISectionData } from "../../App/App.types"
 import "./GradesComponent.css"
 import "../PopupComponent.css"
 
-interface IProps {
-  selectedSection: ISectionData
+interface GradesDetailProps {
+  sectionCode: string
 }
 
-const GradesComponent = ({ selectedSection }: IProps) => {
+const GradesComponent = ({ sectionCode }: GradesDetailProps) => {
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [gradesData, setGradesData] = useState<IGradesAPIData>()
   const [isError, setIsError] = useState<boolean>(false)
@@ -18,7 +17,7 @@ const GradesComponent = ({ selectedSection }: IProps) => {
       setIsLoading(true)
       setIsError(false)
       try {
-        const data = await getGradesData(selectedSection)
+        const data = await getGradesData(sectionCode)
         setGradesData(data)
       } catch (error) {
         setIsError(true)
@@ -27,9 +26,9 @@ const GradesComponent = ({ selectedSection }: IProps) => {
       }
     }
     fetchGrades()
-  }, [selectedSection])
+  }, [])
 
-  const gradesURL = getGradesUrl(selectedSection)
+  const gradesURL = getGradesUrl(sectionCode)
 
   const getClassName = (average: number | undefined) => {
     if (!average) return "AverageContainer unavailable"

--- a/src/content/SectionPopup/GradesComponent/GradesHelper.ts
+++ b/src/content/SectionPopup/GradesComponent/GradesHelper.ts
@@ -1,5 +1,3 @@
-import { ISectionData } from "../../App/App.types"
-
 export interface IGradesAPIData {
   average: number
   averageFiveYears: number
@@ -7,23 +5,23 @@ export interface IGradesAPIData {
   averageMin: number
 }
 
-export const getGradesUrl = (section: ISectionData): string => {
-  const isVancouver = section.code.includes("_V")
+export const getGradesUrl = (sectionCode: string): string => {
+  const isVancouver = sectionCode.includes("_V")
   const campus = isVancouver ? "UBCV" : "UBCO"
-  const courseCode = section.code.split("_")[0]
-  const courseNum = section.code.split(" ")[1].split("-")[0]
+  const courseCode = sectionCode.split("_")[0]
+  const courseNum = sectionCode.split(" ")[1].split("-")[0]
 
   const url = `https://ubcgrades.com/statistics-by-course#${campus}-${courseCode}-${courseNum}`
   return url
 }
 
 export const getGradesData = async (
-  section: ISectionData
+  sectionCode: string
 ): Promise<IGradesAPIData> => {
-  const isVancouver = section.code.includes("_V")
+  const isVancouver = sectionCode.includes("_V")
   const campus = isVancouver ? "UBCV" : "UBCO"
-  const courseCode = section.code.split("_")[0]
-  const courseNum = section.code.split(" ")[1].split("-")[0]
+  const courseCode = sectionCode.split("_")[0]
+  const courseNum = sectionCode.split(" ")[1].split("-")[0]
 
   const reqURL = `https://ubcgrades.com//api/v3/course-statistics/${campus}/${courseCode}/${courseNum}`
   const response = await fetch(reqURL)

--- a/src/content/SectionPopup/SectionInfoBody.tsx
+++ b/src/content/SectionPopup/SectionInfoBody.tsx
@@ -24,18 +24,18 @@ const SectionInfoBody = ({ selectedSection }: SectionInfoProps) => {
 
   return (
     <div className="section-info-body">
-      {selectedSection?.courseID && (
+      {selectedSection.courseID && (
         <a
-          href={`https://wd10.myworkday.com/ubc/d/inst/1$15194/15194$${selectedSection?.courseID}.htmld`}
+          href={`https://wd10.myworkday.com/ubc/d/inst/1$15194/15194$${selectedSection.courseID}.htmld`}
         >
           <div className="SectionPopupTitle">{"<< View Course Page >>"}</div>
         </a>
       )}
       <hr />
-      <div className="SectionPopupDetails">{selectedSection?.name}</div>
+      <div className="SectionPopupDetails">{selectedSection.name}</div>
       <InstructorComponent instructors={selectedSection.instructors} />
       <LocationComponent locations={uniqueLocations} />
-      <GradesComponent selectedSection={selectedSection} />
+      <GradesComponent sectionCode={selectedSection.code} />
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -22,5 +22,5 @@ code {
   --base-1-shaded: #d8d8d8;
   --warning-colour: #ed2121;
   --highlight-colour: #ffa500;
-  --disabled-colour: #f7faff;
+  --disabled-colour: #eeeff0;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -14,10 +14,13 @@ code {
 
 :root {
   --main-accent-colour: #00a7e1;
+  --secondary-accent-colour: #9ce8ff;
   --default-radius: 20px;
   --small-radius: 12px;
   --default-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
   --base-1: #626262;
   --base-1-shaded: #d8d8d8;
   --warning-colour: #ed2121;
+  --highlight-colour: #ffa500;
+  --disabled-colour: #f7faff;
 }


### PR DESCRIPTION
### What Issue does this PR resolve? (Link to GitHub Issue, approved features and bugs will be given priority)
- removes `selectedSection` state - we no longer need it with the new modal layer.
- consolidates the worklist and term tab bars into a single `TabBar` component
    - the export/import modals should probably also be updated to use this, but that'll require more work to move them to the new modal system, so I've left those for now.
- removes unused test file

### Please provide a video demo below, or a screenshot and description of the change.

This is the single visual change (new tab layout):
![Screenshot 2024-06-27 at 01 45 38](https://github.com/mlool/workday-calendar-extension/assets/72814106/d71164f8-dc0d-4e4f-9a96-3f9711407445)

This is more accidental than anything, but I like it - let me know if you want it reverted.

### Tag reviewers for the PR below.
@mlool 