### PR TITLE
fix: add ability for modal bodies to post data back to ModalLayer

### DIFF
--- a/src/content/ManualCourseEntry/ManualCourseEntry.tsx
+++ b/src/content/ManualCourseEntry/ManualCourseEntry.tsx
@@ -6,23 +6,23 @@ import { findCourseInfo } from "../../backends/scheduler/nameSearchApi"
 const ManualCourseEntry = () => {
   const dispatchModal = useContext(ModalDispatchContext)
 
-  const handleManualCourseEntry = () => {
+  const postModal = () => {
     dispatchModal({
       preset: ModalPreset.ManualCourseEntry,
-      additionalData: {
-        onConfirm: async (searchTerm: string, manualUrl: string) => {
-          console.log("reach")
-          const selectedSection = await findCourseInfo(searchTerm, manualUrl)
-          await chrome.storage.local.set({ newSection: selectedSection })
-        },
-      },
+      additionalData: handleManualEntrySubmit,
     })
   }
+
+  const handleManualEntrySubmit = async (manualUrl: string) => {
+    const selectedSection = await findCourseInfo("MANUAL_ENTRY", manualUrl)
+    await chrome.storage.local.set({ newSection: selectedSection })
+  }
+
   return (
     <button
       className="ManualEntryButton"
       title="Manual Entry"
-      onClick={() => handleManualCourseEntry()}
+      onClick={() => postModal()}
     >
       Add Course By Link
     </button>

--- a/src/content/ModalLayer.tsx
+++ b/src/content/ModalLayer.tsx
@@ -77,12 +77,14 @@ function ModalLayer(props: ModalLayerProps) {
   ): ModalConfig | null => {
     switch (action.preset) {
       case ModalPreset.CLEAR:
+        setModalBodyData(undefined)
         return null
       case ModalPreset.ConfirmClearWorklist:
         return {
           title: "Confirm Clear Worklist",
           body: `Clearing the worklist will remove all sections from both terms under worklist ${props.currentWorklistNumber}. Are you sure you want to continue?`,
           closeButtonText: "Cancel",
+          actionType: ModalActionType.Destructive,
           actionButtonText: "Confirm",
           actionHandler: props.handleClearWorklist,
         }
@@ -103,6 +105,7 @@ function ModalLayer(props: ModalLayerProps) {
           body: <SectionInfoBody selectedSection={sectionData} />,
           closeButtonText: "Close",
           actionButtonText: "Remove",
+          actionType: ModalActionType.Destructive,
           actionHandler: () => props.handleDeleteSection(sectionData),
           alignment: ModalAlignment.Top,
           hasTintedBg: false,
@@ -134,7 +137,6 @@ function ModalLayer(props: ModalLayerProps) {
           title: "Error Syncing With Saved Schedule",
           body: errors,
           hasTintedBg: false,
-          actionType: ModalActionType.Normal,
         }
       }
       case ModalPreset.SyncInstructions: {
@@ -143,13 +145,12 @@ function ModalLayer(props: ModalLayerProps) {
 
         return {
           title: "Sync Saved Schedules Instructions",
-          body: `Please note that you must be on the "View Saved Schedules" page. If you have multiple schedules, click the "add course sections" button on the one you which to add to, otherwise it will add to the first one. You must have all requirements (for example class requires lab and lecture) in your worklist`,
+          body: `Note that you must be on the "View Saved Schedules" page. If you have multiple schedules, click the "Add course sections" button on the one you which to add to, otherwise it will add to the first one. You must satisfy all instructional format requirements (for example class requires lab and lecture) in your worklist`,
           closeButtonText: "Close",
           actionButtonText: "OK",
           actionHandler: data.onConfirm,
           cancelHandler: data.onCancel,
           hasTintedBg: false,
-          actionType: ModalActionType.Normal,
         }
       }
       case ModalPreset.SyncConfirm: {
@@ -157,15 +158,13 @@ function ModalLayer(props: ModalLayerProps) {
           title: "Sync Saved Schedules Success",
           body: `Any matching classes were added to this saved schedule! Please refresh page to see changes.`,
           hasTintedBg: false,
-          actionType: ModalActionType.Normal,
         }
       }
       case ModalPreset.ApiError: {
         return {
           title: "Import Error",
-          body: `Oops something went wrong! Best way to fix this is to head to the "Find Course Sections Page" One way to do this is by going "home" by clicking the UBC logo, then clicking "Academics", "Registration & Courses", "Find Course Sections" . If the issue persists, please contact the developers.`,
+          body: `Something went wrong! To fix this, head to the "Find Course Sections Page", accessible from "Home" > "Academics" > "Registration & Courses" > "Find Course Sections". If the issue persists, please contact the developers.`,
           hasTintedBg: false,
-          actionType: ModalActionType.Normal,
         }
       }
       case ModalPreset.ManualCourseEntry: {
@@ -173,9 +172,7 @@ function ModalLayer(props: ModalLayerProps) {
         return {
           title: "Manual Course Entry",
           body: <ManualEntryModalBody handleURLUpdate={setModalBodyData} />,
-          hasTintedBg: true,
           closeButtonText: "Close",
-          actionType: ModalActionType.Normal,
           actionHandlerWithParams: submitHandler,
           actionButtonText: "Add Course",
         }
@@ -259,9 +256,9 @@ function ModalWindow({ modalConfig, bodyData }: ModalWindowProps) {
             modalConfig.actionHandlerWithParams) && (
             <button
               className={`modal-button action-button${
-                modalConfig.actionType === ModalActionType.Normal
-                  ? ""
-                  : "-destructive"
+                modalConfig.actionType === ModalActionType.Destructive
+                  ? "-destructive"
+                  : ""
               }`}
               onClick={handleActionButtonClick}
             >

--- a/src/content/modalBodies/ManualEntryModalBody.css
+++ b/src/content/modalBodies/ManualEntryModalBody.css
@@ -1,0 +1,13 @@
+.manual-entry-body {
+  text-align: center;
+  margin: 20px 10px;
+  font-size: 14px;
+  display: grid;
+  grid-auto-flow: row;
+  row-gap: 8px;
+}
+
+.manual-entry-input {
+  border-radius: var(--small-radius);
+  font-size: 14px;
+}

--- a/src/content/modalBodies/ManualEntryModalBody.tsx
+++ b/src/content/modalBodies/ManualEntryModalBody.tsx
@@ -1,0 +1,22 @@
+import { Dispatch, SetStateAction } from "react"
+import "./ManualEntryModalBody.css"
+
+interface ManualEntryBodyProps {
+  handleURLUpdate: Dispatch<SetStateAction<unknown>>
+}
+
+export default function ManualEntryModalBody(props: ManualEntryBodyProps) {
+  const message =
+    "Want to add a course manually? Click on the course in Workday and paste its URL below."
+  return (
+    <div className="manual-entry-body">
+      <label>{message}</label>
+      <input
+        name="manualEntryUrl"
+        className="manual-entry-input"
+        placeholder="https://wd10.myworkday.com..."
+        onChange={(e) => props.handleURLUpdate(e.target.value)}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
### What Issue does this PR resolve? (Link to GitHub Issue, approved features and bugs will be given priority)
- Fixes an issue where stateful modal bodies were unable to post state that could be passed into the ModalLayer's `actionHandler`
- Changes default `ModalActionType` to `Normal`, instead of `Destructive`
- Cleans up some modal copy

### Please provide a video demo below, or a screenshot and description of the change.

https://github.com/mlool/workday-calendar-extension/assets/72814106/ced12752-d68e-4c31-84ad-08fe124c4a17


### Tag reviewers for the PR below.
@mlool 