### PR TITLE
fix: support rmp for okanagan courses

### DIFF
--- a/src/backends/rateMyProf.ts
+++ b/src/backends/rateMyProf.ts
@@ -17,7 +17,8 @@ interface PartialProf {
 }
 
 export default async function fetchProfRating(
-  profName: string
+  profName: string,
+  isVancouver: boolean
 ): Promise<RMPData | null> {
   const nameParts = profName.split(" ")
   if (nameParts.length < 2) throw "Name does not include both first and last!"
@@ -31,7 +32,7 @@ export default async function fetchProfRating(
   const req = new Request(RMP_API_URL, {
     method: "POST",
     headers,
-    body: JSON.stringify(buildRMPQueryBody(profName)),
+    body: JSON.stringify(buildRMPQueryBody(profName, isVancouver)),
   })
   const rawRes = await fetch(req)
   const res = await rawRes.json()
@@ -55,19 +56,20 @@ export default async function fetchProfRating(
   return null
 }
 
-const buildRMPQueryBody = (profName: string) => {
+const buildRMPQueryBody = (profName: string, isVancouver: boolean) => {
   // request body copied directly from ratemyprofessors.com
+  const schoolID = isVancouver ? "U2Nob29sLTE0MTM=" : "U2Nob29sLTU0MzY="
   return {
     query:
       'query TeacherSearchResultsPageQuery(\n  $query: TeacherSearchQuery!\n  $schoolID: ID\n  $includeSchoolFilter: Boolean!\n) {\n  search: newSearch {\n    ...TeacherSearchPagination_search_1ZLmLD\n  }\n  school: node(id: $schoolID) @include(if: $includeSchoolFilter) {\n    __typename\n    ... on School {\n      name\n    }\n    id\n  }\n}\n\nfragment TeacherSearchPagination_search_1ZLmLD on newSearch {\n  teachers(query: $query, first: 8, after: "") {\n    didFallback\n    edges {\n      cursor\n      node {\n        ...TeacherCard_teacher\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    resultCount\n    filters {\n      field\n      options {\n        value\n        id\n      }\n    }\n  }\n}\n\nfragment TeacherCard_teacher on Teacher {\n  id\n  legacyId\n  avgRating\n  numRatings\n  ...CardFeedback_teacher\n  ...CardSchool_teacher\n  ...CardName_teacher\n  ...TeacherBookmark_teacher\n}\n\nfragment CardFeedback_teacher on Teacher {\n  wouldTakeAgainPercent\n  avgDifficulty\n}\n\nfragment CardSchool_teacher on Teacher {\n  department\n  school {\n    name\n    id\n  }\n}\n\nfragment CardName_teacher on Teacher {\n  firstName\n  lastName\n}\n\nfragment TeacherBookmark_teacher on Teacher {\n  id\n  isSaved\n}\n',
     variables: {
       query: {
         text: profName,
-        schoolID: "U2Nob29sLTE0MTM=",
+        schoolID,
         fallback: false,
         departmentID: null,
       },
-      schoolID: "U2Nob29sLTE0MTM=",
+      schoolID,
       includeSchoolFilter: true,
     },
   }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -16,7 +16,7 @@ Browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     portFromContentScript.postMessage(message.course)
   }
   if (message.type === "RMP") {
-    fetchProfRating(message.prof).then(sendResponse)
+    fetchProfRating(message.prof, message.isVancouver).then(sendResponse)
     return true
   }
 })

--- a/src/content/SectionPopup/InstructorComponent/InstructorComponent.tsx
+++ b/src/content/SectionPopup/InstructorComponent/InstructorComponent.tsx
@@ -9,11 +9,12 @@ import "../PopupComponent.css"
 
 interface IProps {
   instructors: string[]
+  isVancouver: boolean
 }
 
 const RMP_RANGE: ColoredRange = { lowerBound: 0, upperBound: 5 }
 
-const InstructorComponent = ({ instructors }: IProps) => {
+const InstructorComponent = ({ instructors, isVancouver }: IProps) => {
   const [rmpRatings, setRmpRatings] = useState<Record<string, RMPData | null>>()
 
   useEffect(() => {
@@ -30,6 +31,7 @@ const InstructorComponent = ({ instructors }: IProps) => {
         Browser.runtime.sendMessage({
           type: "RMP",
           prof: prof,
+          isVancouver: isVancouver,
         })
       )
     }

--- a/src/content/SectionPopup/SectionInfoBody.tsx
+++ b/src/content/SectionPopup/SectionInfoBody.tsx
@@ -50,6 +50,7 @@ const SectionInfoBody = ({ selectedSection }: SectionInfoProps) => {
       <div className="SectionPopupDetails">{selectedSection.name}</div>
       <InstructorComponent
         instructors={selectedSection.instructors?.filter(Boolean)}
+        isVancouver={selectedSection.code.includes("_V")}
       />
       <LocationComponent locations={uniqueLocations} />
       <GradesComponent sectionCode={selectedSection.code} />

--- a/src/content/utils.ts
+++ b/src/content/utils.ts
@@ -98,14 +98,4 @@ const versionOneFiveZeroUpdateNotification = () => {
     .catch((error) => console.error("Error retrieving flag:", error))
 }
 
-enum Campus {
-  Vancouver,
-  Okanagan,
-}
-
-export {
-  versionOneFiveZeroUpdateNotification,
-  filterSections,
-  extractSection,
-  Campus,
-}
+export { versionOneFiveZeroUpdateNotification, filterSections, extractSection }

--- a/src/content/utils.ts
+++ b/src/content/utils.ts
@@ -98,4 +98,14 @@ const versionOneFiveZeroUpdateNotification = () => {
     .catch((error) => console.error("Error retrieving flag:", error))
 }
 
-export { versionOneFiveZeroUpdateNotification, filterSections, extractSection }
+enum Campus {
+  Vancouver,
+  Okanagan,
+}
+
+export {
+  versionOneFiveZeroUpdateNotification,
+  filterSections,
+  extractSection,
+  Campus,
+}


### PR DESCRIPTION
### What Issue does this PR resolve? (Link to GitHub Issue, approved features and bugs will be given priority)
- Fixes hardcoded UBCV school ID
- RMP ratings should now be shown for okanagan courses as well, with the same caveats as for vancouver (i.e. some profs will not be matched due to name differences between workday/RMP)

### Please provide a video demo below, or a screenshot and description of the change.
- looks the same, just now RMP ratings actually work for UBCO courses (instead of showing `??` for all profs)

### Tag reviewers for the PR below.
@mlool 