### PR TITLE
fix: prevent empty ubcgrades data from violating interface

### DIFF
--- a/src/content/SectionPopup/GradesComponent/GradesComponent.tsx
+++ b/src/content/SectionPopup/GradesComponent/GradesComponent.tsx
@@ -50,7 +50,7 @@ const GradesComponent = ({ sectionCode }: GradesDetailProps) => {
               Average (5 Years)
             </a>
           }
-          numericValue={gradesData ? gradesData?.average : null}
+          numericValue={gradesData ? gradesData?.averageFiveYears : null}
           range={UBC_GRADES_RANGE}
           showRange={false}
           precision={2}

--- a/src/content/SectionPopup/GradesComponent/GradesHelper.ts
+++ b/src/content/SectionPopup/GradesComponent/GradesHelper.ts
@@ -1,6 +1,9 @@
 export interface IGradesAPIData {
-  average: number
-  averageFiveYears: number
+  average: number | null
+  averageFiveYears: number | null
+  // THESE MAY BE NULLABLE, WE DON'T USE THEM RN BUT DON'T
+  // PASS THEM AS NUMBERS CAUSE THIS COULD ACTUALLY BE AN
+  // EMPTY STRING AT RUNTIME
   averageMax: number
   averageMin: number
 }
@@ -28,8 +31,11 @@ export const getGradesData = async (
   if (response.ok) {
     const data = await response.json()
     return {
-      average: data["average"],
-      averageFiveYears: data["average_past_5_yrs"],
+      average: data["average"] === "" ? null : Number(data["average"]),
+      averageFiveYears:
+        data["average_past_5_yrs"] === ""
+          ? null
+          : Number(data["average_past_5_yrs"]),
       averageMax: data["max_course_avg"],
       averageMin: data["min_course_avg"],
     }


### PR DESCRIPTION
### What Issue does this PR resolve? (Link to GitHub Issue, approved features and bugs will be given priority)
- Fix bug where empty UBCGrades data would crash section info popup, by passing non-numeric value into `ColoredRangeDetail`
- Fix incorrect average displayed (incorrectly displayed last year's average, now display average across last 5 years)

### Please provide a video demo below, or a screenshot and description of the change.
No visual changes.

### Tag reviewers for the PR below.
@mlool