### PR TITLE
fix: prevent multiple to one worklist import, wipe old worklists

### DIFF
--- a/assets/chrome-manifest.json
+++ b/assets/chrome-manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "UBC Workday Side by Side Calendar",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Calendar for the new UBC Workday course selection.",
   "icons": {
     "16": "logo16.png",

--- a/assets/firefox-manifest.json
+++ b/assets/firefox-manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "UBC Workday Side by Side Calendar",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Calendar for the new UBC Workday course selection.",
   "icons": {
     "16": "logo16.png",

--- a/src/content/App/App.tsx
+++ b/src/content/App/App.tsx
@@ -174,8 +174,8 @@ function App() {
         preset: ModalPreset.ImportStatus,
         additionalData: (
           <ul style={{ fontSize: "1.2em", padding: "10px" }}>
-            {allSections.errors.map((x) => (
-              <li>{defaultErrorProcessor(x)}</li>
+            {allSections.errors.map((x, index) => (
+              <li key={index}>{defaultErrorProcessor(x)}</li>
             ))}
           </ul>
         ),

--- a/src/storage/errors.ts
+++ b/src/storage/errors.ts
@@ -25,6 +25,7 @@ type ConvertLegacyDetailErr = DataError<
 type FetchWorkdayDataErr = DataError<3, { sectionCode: string }>
 type FetchCourseIdErr = DataError<4, { sectionCode: string }>
 type UndefinedImportErr = DataError<5, undefined>
+type MultipleWorklistInIndividualImportErr = DataError<6, undefined>
 
 /**
  * All recoverable errors generated from the section data layer. Should
@@ -39,6 +40,7 @@ type DataErrors =
   | FetchWorkdayDataErr
   | FetchCourseIdErr
   | UndefinedImportErr
+  | MultipleWorklistInIndividualImportErr
 
 const defaultErrorProcessor = (err: DataErrors): string => {
   switch (err.errorCode) {
@@ -61,6 +63,9 @@ const defaultErrorProcessor = (err: DataErrors): string => {
     }
     case 5: {
       return "Sections to import could not be read!"
+    }
+    case 6: {
+      return "Warning! You are attempting to import sections from multiple worklists into one worklist. This may cause unexpected behavior - please use the 'Import All Worklists' button instead."
     }
   }
 }


### PR DESCRIPTION
### What Issue does this PR resolve? (Link to GitHub Issue, approved features and bugs will be given priority)
- Fix filtering for multiple worklists on import individual, to prevent multiple-to-one worklist import
- Wipe previously-saved sections in a worklist when importing to it through import individual
- Wipe all previously-saved sections on import all
- Fix bug where import individual to worklist 0 did not coerce sections to worklist 0

### Please provide a video demo below, or a screenshot and description of the change.
No visual changes.

### Tag reviewers for the PR below.
@mlool