### PR TITLE
Fixed idSearchApi (Workday changed API)

### DIFF
--- a/src/backends/workday/idSearchApi.ts
+++ b/src/backends/workday/idSearchApi.ts
@@ -15,16 +15,18 @@ export async function fetchWorkdayData(
 ): Promise<ISectionData | null> {
   const rawData = await fetchSearchData(`${searchEndpoint}${courseId}.htmld`)
   handleProgressUpdate(65)
-
-  const path = rawData["body"]["children"][0]["children"][0]["children"]
-  const rawName = path[0]["instances"][0]["text"]
+  const path = rawData["body"]["children"][0]["sections"][0]["children"]
+  const rawName = path[0]["children"][0]["instances"][0]["text"]
   const formattedName = rawName.split(" - ")[1]
   const code =
-    rawData["body"]["children"][1]["children"][0]["values"]["0"]["label"].split(
-      " - "
-    )[0]
+    rawData["body"]["children"][0]["sections"][2]["children"][0]["children"][0][
+      "values"
+    ]["0"]["label"].split(" - ")[0]
+
   const possibleDetailsPath =
-    rawData["body"]["children"][0]["children"][1]["children"]
+    rawData["body"]["children"][0]["sections"][1]["children"][0]["children"][0][
+      "children"
+    ][0]["children"]
 
   const meetingPatternIndex = possibleDetailsPath.findIndex(
     (item: DetailsPath) => item["label"] === "Meeting Patterns"


### PR DESCRIPTION
idSearchApi.ts was broken by Workday's changes to the response on
```ts
`https://wd10.myworkday.com/ubc/inst/1$15194/15194$${courseId}.htmld`
```
<img width="956" alt="Screen Shot 2025-03-29 at 10 43 24 AM" src="https://github.com/user-attachments/assets/c7378b5d-b230-4b3b-a64e-5865cbfb3f8c" />

Can now successfully add the course:
<img width="880" alt="Screen Shot 2025-03-28 at 1 32 04 PM" src="https://github.com/user-attachments/assets/901cbf1f-e9c3-48fe-8f34-94d92df18f7b" />
