### PR TITLE
fix: update section details parsing for new workday api format

### DIFF
--- a/src/backends/workday/idSearchApi.ts
+++ b/src/backends/workday/idSearchApi.ts
@@ -15,12 +15,15 @@ export async function fetchWorkdayData(
 ): Promise<ISectionData | null> {
   const rawData = await fetchSearchData(`${searchEndpoint}${courseId}.htmld`)
   handleProgressUpdate(65)
-  const rawName = rawData['body']['children'][0]['children'][0]['children'][0]['instances'][0]['text']
+  const rawName =
+    rawData["body"]["children"][0]["children"][0]["children"][0][
+      "instances"
+    ][0]["text"]
   const formattedName = rawName.split(" - ")[1]
   const code = rawName.split(" - ")[0]
 
   const possibleDetailsPath =
-    rawData['body']['children'][0]['children'][1]['children'][0]['children']
+    rawData["body"]["children"][0]["children"][1]["children"][0]["children"]
 
   const meetingPatternIndex = possibleDetailsPath.findIndex(
     (item: DetailsPath) => item["label"] === "Meeting Patterns"

--- a/src/backends/workday/idSearchHelpers.ts
+++ b/src/backends/workday/idSearchHelpers.ts
@@ -92,7 +92,8 @@ export const parseSectionDetails = (details: string[]): SectionDetail[] => {
 
   details.forEach((detail) => {
     const detailParts = detail.split(" | ")
-    if (detailParts.length !== 3 && detailParts.length !== 4) {
+
+    if (detailParts.length !== 7) {
       alert(JSON.stringify(detailParts))
       alert("Invalid section details format")
     }
@@ -101,13 +102,8 @@ export const parseSectionDetails = (details: string[]): SectionDetail[] => {
     let timeRange = ""
     let dateRange = ""
 
-    if (detailParts.length === 3) {
-      // Without location
-      ;[daysString, timeRange, dateRange] = detailParts
-    } else {
-      // With location
-      ;[location, daysString, timeRange, dateRange] = detailParts
-    }
+    ;[dateRange, timeRange, daysString, location] = detailParts.reverse()
+    location = location.slice(1, 4)
 
     let days = daysString.split(" ")
     let [startTime, endTime] = timeRange.split(" - ")


### PR DESCRIPTION
fix for [this bug](https://discord.com/channels/1245111270005542962/1245386686909780058/1400980924442873886) - workday changed their meeting pattern string's format. this seems to work, but there may be untested edge cases i haven't run across - that being said, something is better than nothing?

also, ran formatter/linter.