### PR TITLE
Fix location and edge case of lab section issue

### DIFF
--- a/src/backends/workday/idSearchHelpers.ts
+++ b/src/backends/workday/idSearchHelpers.ts
@@ -84,26 +84,45 @@ export function parseSessionAndTerms(rawTerm: string[]): {
   return { session: finalSessions.values().next().value, terms: finalTerms }
 }
 
-/**
- * SCRF-Floor 1-Room 100 | Tue Thu | 11:00 a.m. - 12:30 p.m. | 2024-09-03 - 2024-12-05
- */
 export const parseSectionDetails = (details: string[]): SectionDetail[] => {
   let detailsArr: SectionDetail[] = []
 
   details.forEach((detail) => {
     const detailParts = detail.split(" | ")
 
-    if (detailParts.length !== 7) {
+    const daysOfWeek = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+
+    let location,
+      daysString,
+      timeRange,
+      dateRange,
+      buildingName,
+      floorNumber,
+      roomNumber = ""
+
+    // Handle edge case for lab sections that may hide some details
+    // E.g. ["Fri | 2:00 p.m. - 5:00 p.m. | 2026-01-09 - 2026-02-13"]
+    if (detailParts.length === 3) {
+      ;[daysString, timeRange, dateRange] = detailParts
+
+      location = "TBA"
+
+      // E.g. ["UBCV","Buchanan Building (BUCH)","Floor: 2","Room: D222","Tue Thu","9:30 a.m. - 11:00 a.m.","2026-02-24 - 2026-04-09"]
+    } else if (detailParts.length === 7) {
+      ;[
+        dateRange,
+        timeRange,
+        daysString,
+        roomNumber,
+        floorNumber,
+        buildingName,
+      ] = detailParts.reverse()
+
+      location = `${buildingName} - ${floorNumber} - ${roomNumber}`
+    } else {
       alert(JSON.stringify(detailParts))
       alert("Invalid section details format")
     }
-    let location = ""
-    let daysString = ""
-    let timeRange = ""
-    let dateRange = ""
-
-    ;[dateRange, timeRange, daysString, location] = detailParts.reverse()
-    location = location.slice(1, 4)
 
     let days = daysString.split(" ")
     let [startTime, endTime] = timeRange.split(" - ")
@@ -112,8 +131,6 @@ export const parseSectionDetails = (details: string[]): SectionDetail[] => {
     endTime = convertTo24HourFormat(endTime)
 
     //Handle the "Fri (Alternate Weeks)" case, or any text that isn't a valid day
-    const daysOfWeek = ["Mon", "Tue", "Wed", "Thu", "Fri"]
-
     days = days.reduce<string[]>((acc, str) => {
       const firstThreeChars = str.substring(0, 3)
 


### PR DESCRIPTION
## Changes:

Corrected parsing logic for course location data.

Added handling for lab sections where details may not follow the standard format.

Fixes: [#194](https://github.com/mlool/workday-calendar-extension/issues/194)

Partially: [#195](https://github.com/mlool/workday-calendar-extension/issues/195) (instructor data still needs a proper fix)

### Screenshot after changes

<img width="418" height="911" alt="image" src="https://github.com/user-attachments/assets/e4308ec1-7881-426f-b0f6-e45186a005fc" />

Adding lab sections that were failing (CHEM_V 121-L72, MATH_V 152-L2E, CHEM_V 123-L91)

<img width="1915" height="961" alt="image" src="https://github.com/user-attachments/assets/57afcdca-4311-4b96-8652-c086fddf8f78" />

<img width="447" height="936" alt="image" src="https://github.com/user-attachments/assets/9c7903c9-b243-442c-9572-01807746c5c6" />

