### PR TITLE
fix: update instructor parsing for new api response

### DIFF
--- a/src/backends/workday/idSearchApi.ts
+++ b/src/backends/workday/idSearchApi.ts
@@ -33,7 +33,11 @@ export async function fetchWorkdayData(
   for (const detail of detailsPath) {
     rawDetails.push(detail["text"])
   }
-  const instructorsIndex = possibleDetailsPath.findIndex(
+
+  const instructorDetailsPath =
+    rawData["body"]["children"][0]["children"][0]["children"]
+
+  const instructorsIndex = instructorDetailsPath.findIndex(
     (item: DetailsPath) => item["widget"] === "panel"
   )
 
@@ -41,9 +45,7 @@ export async function fetchWorkdayData(
   if (instructorsIndex !== -1) {
     try {
       const instructorsPath =
-        possibleDetailsPath[instructorsIndex]["children"][0]["children"][0][
-          "instances"
-        ]
+        instructorDetailsPath[instructorsIndex]["children"][0]["instances"]
       for (const instructor of instructorsPath) {
         instructors.push(instructor["text"])
       }


### PR DESCRIPTION
it's no longer possible to get instructors data through `possibleDetailsPath`, had to fiddle with our walk through the return JSON to get us to the correct object with the data.

closes #195 (at least, the parts not addressed by #196)