### PR TITLE
Weekend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ use Yarn Classic (latest 1.x) - please do not use Yarn Modern.
 
 1. Clone the repo
    ```bash
-   git clone git@github.com:mlool/workday-calendar-extension.git
+   git clone https://github.com/mlool/workday-calendar-extension.git
    ```
 2. Navigate to the root directory and install dependencies:
    ```bash

--- a/assets/chrome-manifest.json
+++ b/assets/chrome-manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "UBC Workday Side by Side Calendar",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Calendar for the new UBC Workday course selection.",
   "icons": {
     "16": "logo16.png",

--- a/assets/firefox-manifest.json
+++ b/assets/firefox-manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "UBC Workday Side by Side Calendar",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Calendar for the new UBC Workday course selection.",
   "icons": {
     "16": "logo16.png",

--- a/src/backends/workday/idSearchApi.ts
+++ b/src/backends/workday/idSearchApi.ts
@@ -204,6 +204,13 @@ export async function extractSection(element: Element) {
   if (!fetchedSection) {
     throw new Error("Section failed to be fetched");
   }
+  const isWeekendDisplayEnabled =
+    await ExtensionStorage.getIsWeekendDisplayEnabled();
+  if (!isWeekendDisplayEnabled && fetchedSection.hasWeekendSchedule()) {
+    throw new Error(
+      "This section includes Saturday or Sunday meetings. Enable Weekend Display in Settings before adding weekend sections."
+    );
+  }
   await ExtensionStorage.setNewSection(fetchedSection);
 }
 

--- a/src/content/App/App.tsx
+++ b/src/content/App/App.tsx
@@ -40,6 +40,8 @@ function App() {
     ExtensionViews.calendar
   );
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
+  const [isWeekendDisplayEnabled, setIsWeekendDisplayEnabled] =
+    useState<boolean>(false);
 
   useEffect(() => {
     const syncInitialStorage = async () => {
@@ -70,6 +72,9 @@ function App() {
       if (fetchedCurrentWorklist) {
         setCurrWorklist(fetchedCurrentWorklist);
       }
+      const fetchedIsWeekendDisplayEnabled =
+        await ExtensionStorage.getIsWeekendDisplayEnabled();
+      setIsWeekendDisplayEnabled(fetchedIsWeekendDisplayEnabled);
       setIsLoaded(true);
     };
 
@@ -102,6 +107,10 @@ function App() {
         const newVal: number | null = changes.currentWorklist.newValue;
         if (newVal === null) return;
         setCurrWorklist(newVal);
+      } else if (changes.isWeekendDisplayEnabled) {
+        const newVal: boolean | null = changes.isWeekendDisplayEnabled.newValue;
+        if (newVal === null) return;
+        setIsWeekendDisplayEnabled(newVal);
       }
     };
 
@@ -182,7 +191,12 @@ function App() {
       </div>
       <ProgressModal />
       {currentView === ExtensionViews.setting ? (
-        <Setting schedule={schedule} setSchedule={setSchedule} />
+        <Setting
+          schedule={schedule}
+          setSchedule={setSchedule}
+          isWeekendDisplayEnabled={isWeekendDisplayEnabled}
+          setIsWeekendDisplayEnabled={setIsWeekendDisplayEnabled}
+        />
       ) : (
         <>
           <CalendarControls
@@ -200,6 +214,7 @@ function App() {
             worklist={currWorklist}
             term={currentTerm}
             session={currentSession}
+            isWeekendDisplayEnabled={isWeekendDisplayEnabled}
             setSelectedSection={setSelectedSection}
           />
           <NewSectionControl
@@ -229,6 +244,7 @@ function App() {
                 );
                 setSelectedSection(null);
               }}
+              isWeekendDisplayEnabled={isWeekendDisplayEnabled}
               setNewSection={setNewSection}
               setSchedule={setSchedule}
             />

--- a/src/content/App/App.tsx
+++ b/src/content/App/App.tsx
@@ -195,7 +195,6 @@ function App() {
           schedule={schedule}
           setSchedule={setSchedule}
           isWeekendDisplayEnabled={isWeekendDisplayEnabled}
-          setIsWeekendDisplayEnabled={setIsWeekendDisplayEnabled}
         />
       ) : (
         <>

--- a/src/content/Calendar/Calendar.css
+++ b/src/content/Calendar/Calendar.css
@@ -8,6 +8,10 @@
   overflow: hidden;
 }
 
+.calendar--weekends-enabled {
+  min-width: 620px;
+}
+
 .calendar-header {
   display: flex;
   border-bottom: 1px solid var(--border-color);
@@ -37,7 +41,8 @@
 .calendar-body {
   display: flex;
   flex: 1;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
   padding: 10px 0;
   position: relative;
 }

--- a/src/content/Calendar/Calendar.tsx
+++ b/src/content/Calendar/Calendar.tsx
@@ -9,6 +9,7 @@ interface IProps {
   worklist: number;
   term: number;
   session: string;
+  isWeekendDisplayEnabled: boolean;
   setSelectedSection: (section: Section | null) => void;
 }
 
@@ -19,7 +20,8 @@ const TOTAL_MINUTES = (END_HOUR - START_HOUR) * 60;
 const CONFLICT_COLOR = "var(--conflict-color)";
 const NEW_SECTION_COLOR = "var(--new-section-color)";
 
-const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri"];
+const WEEKDAY_DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri"];
+const WEEKEND_DAYS = ["Sat", "Sun"];
 
 const Calendar: React.FC<IProps> = ({
   schedule,
@@ -27,6 +29,7 @@ const Calendar: React.FC<IProps> = ({
   worklist,
   term,
   session,
+  isWeekendDisplayEnabled,
   setSelectedSection,
 }) => {
   const [scheduleSectionSchedules, setScheduleSectionSchedules] =
@@ -112,11 +115,19 @@ const Calendar: React.FC<IProps> = ({
     return lines;
   };
 
+  const days = isWeekendDisplayEnabled
+    ? [...WEEKDAY_DAYS, ...WEEKEND_DAYS]
+    : WEEKDAY_DAYS;
+
   return (
-    <div className="calendar">
+    <div
+      className={`calendar ${
+        isWeekendDisplayEnabled ? "calendar--weekends-enabled" : ""
+      }`}
+    >
       <div className="calendar-header">
         <div className="time-gutter-header"></div>
-        {DAYS.map((day) => (
+        {days.map((day) => (
           <div key={day} className="day-header">
             {day}
           </div>
@@ -137,7 +148,7 @@ const Calendar: React.FC<IProps> = ({
             {renderGridLines()}
           </div>
 
-          {DAYS.map((day) => {
+          {days.map((day) => {
             const daySchedule = scheduleSectionSchedules.filter((s) =>
               s.day.includes(day)
             );

--- a/src/content/CustomSectionDetails/CustomSectionDetails.tsx
+++ b/src/content/CustomSectionDetails/CustomSectionDetails.tsx
@@ -13,11 +13,13 @@ interface IProps {
   session: string;
   onClose: () => void;
   onDelete: (section: Section) => void;
+  isWeekendDisplayEnabled: boolean;
   setNewSection: (section: Section | null) => void;
   setSchedule: (schedule: Schedule) => void;
 }
 
-const DAYS_OF_WEEK = ["Mon", "Tue", "Wed", "Thu", "Fri"];
+const WEEKDAY_DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri"];
+const WEEKEND_DAYS = ["Sat", "Sun"];
 
 // Generate 30-min interval times
 const TIME_OPTIONS: string[] = [];
@@ -33,9 +35,13 @@ const CustomSectionDetails = ({
   session,
   onClose,
   onDelete,
+  isWeekendDisplayEnabled,
   setNewSection,
   setSchedule,
 }: IProps) => {
+  const daysOfWeek = isWeekendDisplayEnabled
+    ? [...WEEKDAY_DAYS, ...WEEKEND_DAYS]
+    : WEEKDAY_DAYS;
   const [title, setTitle] = useState("");
   const [notes, setNotes] = useState("");
   const [selectedTerms, setSelectedTerms] = useState<Set<number>>(
@@ -271,7 +277,7 @@ const CustomSectionDetails = ({
           <div className="input-group">
             <label className="input-label">Days</label>
             <div className="day-selector">
-              {DAYS_OF_WEEK.map((day) => (
+              {daysOfWeek.map((day) => (
                 <button
                   key={day}
                   className={`custom-control-button ${

--- a/src/content/NewSectionControl/SectionFromURL.tsx
+++ b/src/content/NewSectionControl/SectionFromURL.tsx
@@ -3,6 +3,9 @@ import ExtensionStorage from "../../objects/ExtensionStorage";
 import "./SectionFromURL.css";
 import { useState } from "react";
 
+const WEEKEND_ALERT_MESSAGE =
+  "This section includes Saturday or Sunday meetings. Enable Weekend Display in Settings before adding weekend sections.";
+
 interface IProps {
   onClose: () => void;
 }
@@ -12,9 +15,15 @@ const SectionFromURL: React.FC<IProps> = ({ onClose }) => {
 
   const onClick = () => {
     fetchSectionFromUrl(url)
-      .then((section) => {
+      .then(async (section) => {
         if (section) {
-          ExtensionStorage.setNewSection(section);
+          const isWeekendDisplayEnabled =
+            await ExtensionStorage.getIsWeekendDisplayEnabled();
+          if (!isWeekendDisplayEnabled && section.hasWeekendSchedule()) {
+            alert(WEEKEND_ALERT_MESSAGE);
+            return;
+          }
+          await ExtensionStorage.setNewSection(section);
           onClose();
         }
       })

--- a/src/content/Setting/Setting.tsx
+++ b/src/content/Setting/Setting.tsx
@@ -53,9 +53,30 @@ const batchImportExportInfo = (
 interface IProps {
   schedule: Schedule;
   setSchedule: (schedule: Schedule) => void;
+  isWeekendDisplayEnabled: boolean;
+  setIsWeekendDisplayEnabled: (enabled: boolean) => void;
 }
 
-const Setting = ({ schedule, setSchedule }: IProps) => {
+const weekendDisplayInfo = (
+  <div>
+    <p>
+      Weekend Display adds Saturday and Sunday columns to the calendar and
+      allows weekend custom sections and exports.
+    </p>
+    <br />
+    <p>
+      You cannot turn it off while any existing section is scheduled on a
+      weekend.
+    </p>
+  </div>
+);
+
+const Setting = ({
+  schedule,
+  setSchedule,
+  isWeekendDisplayEnabled,
+  setIsWeekendDisplayEnabled,
+}: IProps) => {
   const [showInfoModal, setShowInfoModal] = useState<JSX.Element | null>(null);
   const [isAutoFill, setIsAutoFill] = useState(false);
   const [isConflictAdding, setIsConflictAdding] = useState(false);
@@ -73,6 +94,18 @@ const Setting = ({ schedule, setSchedule }: IProps) => {
   const toggleConflictAdding = (checked: boolean) => {
     setIsConflictAdding(checked);
     ExtensionStorage.setIsConflictAddingEnabled(checked);
+  };
+
+  const toggleWeekendDisplay = async (checked: boolean) => {
+    if (!checked && schedule.getWeekendSections().length > 0) {
+      alert(
+        "Remove all sections scheduled on Saturday or Sunday before turning Weekend Display off."
+      );
+      return;
+    }
+
+    setIsWeekendDisplayEnabled(checked);
+    await ExtensionStorage.setIsWeekendDisplayEnabled(checked);
   };
 
   return (
@@ -121,6 +154,26 @@ const Setting = ({ schedule, setSchedule }: IProps) => {
             type="checkbox"
             checked={isConflictAdding}
             onChange={(e) => toggleConflictAdding(e.target.checked)}
+          />
+          <span className="setting-slider"></span>
+        </label>
+      </div>
+
+      <div className="setting-row">
+        <div className="setting-label-group">
+          <label className="setting-label">Weekend Display</label>
+          <InfoSquareIcon
+            size={16}
+            onClick={() => {
+              setShowInfoModal(weekendDisplayInfo);
+            }}
+          />
+        </div>
+        <label className="setting-toggle">
+          <input
+            type="checkbox"
+            checked={isWeekendDisplayEnabled}
+            onChange={(e) => void toggleWeekendDisplay(e.target.checked)}
           />
           <span className="setting-slider"></span>
         </label>

--- a/src/content/Setting/Setting.tsx
+++ b/src/content/Setting/Setting.tsx
@@ -54,7 +54,6 @@ interface IProps {
   schedule: Schedule;
   setSchedule: (schedule: Schedule) => void;
   isWeekendDisplayEnabled: boolean;
-  setIsWeekendDisplayEnabled: (enabled: boolean) => void;
 }
 
 const weekendDisplayInfo = (
@@ -75,7 +74,6 @@ const Setting = ({
   schedule,
   setSchedule,
   isWeekendDisplayEnabled,
-  setIsWeekendDisplayEnabled,
 }: IProps) => {
   const [showInfoModal, setShowInfoModal] = useState<JSX.Element | null>(null);
   const [isAutoFill, setIsAutoFill] = useState(false);
@@ -104,7 +102,6 @@ const Setting = ({
       return;
     }
 
-    setIsWeekendDisplayEnabled(checked);
     await ExtensionStorage.setIsWeekendDisplayEnabled(checked);
   };
 

--- a/src/domManipulators/addSectionButton.ts
+++ b/src/domManipulators/addSectionButton.ts
@@ -74,7 +74,13 @@ function addButtonToElement(
 // Function to handle button click event
 async function handleButtonClick(element: Element): Promise<void> {
   toggleContainer(true);
-  await extractSection(element);
+  try {
+    await extractSection(element);
+  } catch (error) {
+    if (error instanceof Error) {
+      alert(error.message);
+    }
+  }
 }
 
 // Function to observe DOM changes and add buttons to matching elements

--- a/src/objects/ExtensionStorage.ts
+++ b/src/objects/ExtensionStorage.ts
@@ -163,4 +163,18 @@ export default class ExtensionStorage {
   ): Promise<void> {
     await chrome.storage.local.set({ isConflictAddingEnabled });
   }
+
+  static async getIsWeekendDisplayEnabled(): Promise<boolean> {
+    const isWeekendDisplayEnabled = (
+      await chrome.storage.local.get("isWeekendDisplayEnabled")
+    ).isWeekendDisplayEnabled;
+    if (isWeekendDisplayEnabled === undefined) return false;
+    return Boolean(isWeekendDisplayEnabled);
+  }
+
+  static async setIsWeekendDisplayEnabled(
+    isWeekendDisplayEnabled: boolean
+  ): Promise<void> {
+    await chrome.storage.local.set({ isWeekendDisplayEnabled });
+  }
 }

--- a/src/objects/Schedule.ts
+++ b/src/objects/Schedule.ts
@@ -32,6 +32,13 @@ export default class Schedule {
   async addSection(section: Section): Promise<Schedule> {
     const isConflictAddingEnabled =
       await ExtensionStorage.getIsConflictAddingEnabled();
+    const isWeekendDisplayEnabled =
+      await ExtensionStorage.getIsWeekendDisplayEnabled();
+    if (!isWeekendDisplayEnabled && section.hasWeekendSchedule()) {
+      throw new Error(
+        "This section includes Saturday or Sunday meetings. Enable Weekend Display in Settings before adding weekend sections."
+      );
+    }
     if (
       !isConflictAddingEnabled &&
       this.getConflictSections(section).length > 0
@@ -162,6 +169,19 @@ export default class Schedule {
       });
     });
     return conflicts;
+  }
+
+  getWeekendSections(worklistNumber?: number, session?: string): Section[] {
+    return this.data.filter((section: Section) => {
+      if (
+        worklistNumber !== undefined &&
+        section.getWorklistNumber() !== worklistNumber
+      )
+        return false;
+      if (session !== undefined && section.getSession() !== session)
+        return false;
+      return section.hasWeekendSchedule();
+    });
   }
 
   // Gets all available sessions (2025W, etc) in the schedule

--- a/src/objects/Section.ts
+++ b/src/objects/Section.ts
@@ -15,6 +15,8 @@ export interface IGradesAPIData {
   averageFiveYears: number | null;
 }
 
+const WEEKEND_DAYS = new Set(["Sat", "Sun"]);
+
 export default class Section {
   private code: string; // Course Code, eg. CPSC_V 100
   private courseID: string; // Workday Course ID, eg "458290", if custom a random guid string
@@ -209,6 +211,12 @@ export default class Section {
             return [key, item];
           })
       ).values()
+    );
+  }
+
+  hasWeekendSchedule(term?: number[]): boolean {
+    return this.getSectionSchedule(term).some((schedule) =>
+      schedule.day.some((day) => WEEKEND_DAYS.has(day))
     );
   }
 

--- a/tests/scheduleTests/schedule.test.ts
+++ b/tests/scheduleTests/schedule.test.ts
@@ -9,6 +9,7 @@ jest.mock("../../src/objects/ExtensionStorage", () => ({
   __esModule: true,
   default: {
     getIsConflictAddingEnabled: jest.fn().mockResolvedValue(true),
+    getIsWeekendDisplayEnabled: jest.fn().mockResolvedValue(true),
   },
 }));
 
@@ -18,6 +19,9 @@ let sectionDetail2: SectionDetail;
 beforeEach(() => {
   jest.spyOn(console, "error").mockImplementation(() => {});
   (ExtensionStorage.getIsConflictAddingEnabled as jest.Mock).mockResolvedValue(
+    true
+  );
+  (ExtensionStorage.getIsWeekendDisplayEnabled as jest.Mock).mockResolvedValue(
     true
   );
   sectionDetail0 = SectionDetail.getSectionDetailFromJSON(
@@ -225,6 +229,70 @@ describe("Schedule Tests", () => {
     schedule = await schedule.addSection(sectionW1);
     schedule = await schedule.addSection(sectionW2);
     expect(schedule.getLatestSession()).toBe("2025W");
+  });
+
+  test("addSection rejects weekend sections when weekend display is disabled", async () => {
+    const weekendDetail = new SectionDetail([1], ["Sat"], "10:00", "11:00");
+    const weekendSection = new Section(
+      "TEST_V 100",
+      "weekend-1",
+      [],
+      [weekendDetail],
+      "2025W",
+      0,
+      "blue",
+      "001",
+      "Lecture",
+      "Weekend Section",
+      false
+    );
+
+    (ExtensionStorage.getIsWeekendDisplayEnabled as jest.Mock).mockResolvedValue(
+      false
+    );
+
+    await expect(
+      new Schedule(Schedule.getVersion(), []).addSection(weekendSection)
+    ).rejects.toThrow(
+      "This section includes Saturday or Sunday meetings. Enable Weekend Display in Settings before adding weekend sections."
+    );
+  });
+
+  test("getWeekendSections returns only weekend sections", () => {
+    const weekdaySection = new Section(
+      "TEST_V 101",
+      "weekday-1",
+      [],
+      [new SectionDetail([1], ["Mon"], "10:00", "11:00")],
+      "2025W",
+      0,
+      "blue",
+      "001",
+      "Lecture",
+      "Weekday Section",
+      false
+    );
+    const weekendSection = new Section(
+      "TEST_V 102",
+      "weekend-2",
+      [],
+      [new SectionDetail([1], ["Sun"], "12:00", "13:00")],
+      "2025W",
+      1,
+      "red",
+      "001",
+      "Lecture",
+      "Weekend Section",
+      false
+    );
+
+    const schedule = new Schedule(Schedule.getVersion(), [
+      weekdaySection,
+      weekendSection,
+    ]);
+
+    expect(schedule.getWeekendSections()).toEqual([weekendSection]);
+    expect(schedule.getWeekendSections(1, "2025W")).toEqual([weekendSection]);
   });
 
   test("get colors", async () => {

--- a/tests/sectionTests/section.test.ts
+++ b/tests/sectionTests/section.test.ts
@@ -153,6 +153,26 @@ describe("Section tests", () => {
     });
   });
 
+  test("hasWeekendSchedule detects weekend meetings", () => {
+    expect(section.hasWeekendSchedule()).toBe(false);
+
+    const weekendSection = new Section(
+      "TEST",
+      "weekend",
+      [],
+      [new SectionDetail([1], ["Sat", "Sun"], "09:00", "10:00")],
+      "2025W",
+      0,
+      "blue",
+      "001",
+      "Lecture",
+      "Weekend",
+      false
+    );
+
+    expect(weekendSection.hasWeekendSchedule()).toBe(true);
+  });
+
   test("testing get historical grades first with custom course then without", async () => {
     const sectionCustom = new Section(
       "DSCI_V 200",


### PR DESCRIPTION
## Summary

Adds an optional `Weekend Display` setting that enables Saturday/Sunday support across the extension.

When enabled, the calendar renders weekend columns and custom sections can be scheduled on weekends. When disabled, weekend sections cannot be added through the add-section flow or manual URL import, and users are prompted to enable the setting first. Turning the setting off is blocked if there are already weekend sections in the schedule.

## Changes

- Added persistent `isWeekendDisplayEnabled` storage support in `src/objects/ExtensionStorage.ts`
- Added `Weekend Display` toggle to settings in `src/content/Setting/Setting.tsx`
- Wired app state to react to storage changes for weekend display in `src/content/App/App.tsx`
- Updated calendar rendering to optionally include `Sat` and `Sun` columns in `src/content/Calendar/Calendar.tsx`
- Adjusted calendar layout to remain usable with extra columns in `src/content/Calendar/Calendar.css`
- Enabled weekend day selection for custom sections when the setting is on in `src/content/CustomSectionDetails/CustomSectionDetails.tsx`
- Added shared weekend detection helpers on `Section`/`Schedule` in `src/objects/Section.ts` and `src/objects/Schedule.ts`
- Blocked weekend section staging/add flows when the setting is off in:
  - `src/backends/workday/idSearchApi.ts`
  - `src/domManipulators/addSectionButton.ts`
  - `src/content/NewSectionControl/SectionFromURL.tsx`
- Added test coverage for weekend detection and add restrictions in:
  - `tests/sectionTests/section.test.ts`
  - `tests/scheduleTests/schedule.test.ts`

## Behavior

### Weekend Display = ON
- Calendar shows Saturday and Sunday columns
- Custom sections can be assigned to Saturday and Sunday
- Weekend events are included in ICS export

### Weekend Display = OFF
- Add Section and manual URL import reject sections with Saturday/Sunday meetings
- Users see an alert instructing them to enable Weekend Display in Settings

### Toggling ON -> OFF
- If any existing section is scheduled on Saturday or Sunday, the toggle is blocked
- Users are instructed to remove those sections first

## Validation

- `yarn test --runInBand tests/scheduleTests/schedule.test.ts tests/sectionTests/section.test.ts`
- `yarn eslint "src/**/*.tsx" "src/**/*.ts" "tests/**/*.ts"`
- `yarn build-chrome`